### PR TITLE
Use OpenAI base url from parameters

### DIFF
--- a/custom_components/home_agent/vector_db_manager.py
+++ b/custom_components/home_agent/vector_db_manager.py
@@ -13,6 +13,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable, Sequence, cast
 
 import aiohttp
+import homeassistant.helpers.httpx_client
+import httpx
 from homeassistant.components import conversation as ha_conversation
 from homeassistant.components.homeassistant.exposed_entities import async_should_expose
 from homeassistant.const import EVENT_STATE_CHANGED
@@ -570,14 +572,21 @@ class VectorDBManager:
             )
 
         # Create OpenAI client with API key
-        client = openai.OpenAI(api_key=self.openai_api_key, base_url=self.embedding_base_url)
+        client = openai.AsyncOpenAI(
+            api_key=self.openai_api_key,
+            base_url=self.embedding_base_url,
+            http_client=homeassistant.helpers.httpx_client.get_async_client(hass=self.hass),
+        )
 
         # Use the new API for embeddings
-        response = await self.hass.async_add_executor_job(
-            lambda: client.embeddings.create(
-                model=self.embedding_model,
-                input=text,
-            )
+        async def _request() -> openai.types.CreateEmbeddingResponse:
+            return await client.embeddings.create(model=self.embedding_model, input=text)
+
+        response = await retry_async(
+            _request,
+            max_retries=3,
+            retryable_exceptions=(httpx.HTTPError,),
+            non_retryable_exceptions=(openai.OpenAIError,),
         )
         embedding: list[float] = response.data[0].embedding
         return embedding


### PR DESCRIPTION
# Pull Request

## Description

### What does this PR do?
Consider the Embedding API Base URL for the OpenAI embedding provider.


### Why is this change needed?
It was impossible to use OpenAI compatible embedding providers that are not OpenAI


## Related Issues

<!-- Link to related issues using the format below -->
Fixes #6 

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] Tests added/updated (if applicable)
- [ ] All tests pass locally
- [x] Code formatted with `black` and `isort`
- [x] Code linted with `flake8`, `pylint`, and `mypy` (no critical issues)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if applicable)  **Does not exist!**

## Testing

### How was this tested?
Manual testing


### Test Coverage
<!-- If applicable, provide test coverage percentage or mention coverage changes -->
- Coverage: _%

## Additional Notes

<!-- Any additional information, screenshots, or context that reviewers should know -->


---

<!-- Please review CONTRIBUTING.md (if available) before submitting your PR -->
