### PR TITLE
feat: Add support for exposing labels to llm

### DIFF
--- a/custom_components/home_agent/config_flow.py
+++ b/custom_components/home_agent/config_flow.py
@@ -66,6 +66,7 @@ from .const import (
     CONF_MEMORY_MIN_WORDS,
     CONF_OPENAI_API_KEY,
     CONF_PROMPT_CUSTOM_ADDITIONS,
+    CONF_PROMPT_INCLUDE_LABELS,
     CONF_PROMPT_USE_DEFAULT,
     CONF_SESSION_PERSISTENCE_ENABLED,
     CONF_SESSION_TIMEOUT,
@@ -116,6 +117,7 @@ from .const import (
     DEFAULT_MEMORY_MIN_IMPORTANCE,
     DEFAULT_MEMORY_MIN_WORDS,
     DEFAULT_NAME,
+    DEFAULT_PROMPT_INCLUDE_LABELS,
     DEFAULT_PROMPT_USE_DEFAULT,
     DEFAULT_SESSION_PERSISTENCE_ENABLED,
     DEFAULT_SESSION_TIMEOUT,
@@ -562,9 +564,7 @@ class HomeAgentOptionsFlow(config_entries.OptionsFlow):
                 # Note: async_update_entry is synchronous despite the name in HA
                 new_data = {**self._config_entry.data, **user_input}
                 _LOGGER.debug("Updating config entry data to: %s", new_data)
-                self.hass.config_entries.async_update_entry(
-                    self._config_entry, data=new_data
-                )
+                self.hass.config_entries.async_update_entry(self._config_entry, data=new_data)
                 _LOGGER.debug("Config entry data updated successfully")
 
                 # Return current options to preserve them
@@ -598,9 +598,7 @@ class HomeAgentOptionsFlow(config_entries.OptionsFlow):
                     ): str,
                     vol.Optional(
                         CONF_LLM_API_KEY,
-                        description={
-                            "suggested_value": current_data.get(CONF_LLM_API_KEY, "")
-                        },
+                        description={"suggested_value": current_data.get(CONF_LLM_API_KEY, "")},
                     ): str,
                     vol.Required(
                         CONF_LLM_MODEL,
@@ -956,6 +954,15 @@ class HomeAgentOptionsFlow(config_entries.OptionsFlow):
                         default=current_options.get(
                             CONF_PROMPT_USE_DEFAULT,
                             current_data.get(CONF_PROMPT_USE_DEFAULT, DEFAULT_PROMPT_USE_DEFAULT),
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_PROMPT_INCLUDE_LABELS,
+                        default=current_options.get(
+                            CONF_PROMPT_INCLUDE_LABELS,
+                            current_data.get(
+                                CONF_PROMPT_INCLUDE_LABELS, DEFAULT_PROMPT_INCLUDE_LABELS
+                            ),
                         ),
                     ): bool,
                     vol.Optional(

--- a/custom_components/home_agent/const.py
+++ b/custom_components/home_agent/const.py
@@ -70,6 +70,7 @@ CONF_ENTITY_PRIORITY_WEIGHTS: Final = "entity_priority_weights"
 CONF_PROMPT_USE_DEFAULT: Final = "prompt_use_default"
 CONF_PROMPT_CUSTOM: Final = "prompt_custom"
 CONF_PROMPT_CUSTOM_ADDITIONS: Final = "prompt_custom_additions"
+CONF_PROMPT_INCLUDE_LABELS: Final = "prompt_include_labels"
 
 # Configuration keys - Tool Configuration
 CONF_TOOLS_ENABLE_NATIVE: Final = "tools_enable_native"
@@ -191,6 +192,7 @@ DEFAULT_SUMMARIZATION_ENABLED: Final = False
 
 # Default values - System Prompt
 DEFAULT_PROMPT_USE_DEFAULT: Final = True
+DEFAULT_PROMPT_INCLUDE_LABELS: Final = False
 
 # Default values - Tool Configuration
 DEFAULT_TOOLS_ENABLE_NATIVE: Final = True
@@ -799,7 +801,7 @@ Current Time: {{now()}}
 
 Available Devices (CHECK THIS FIRST BEFORE ANY TOOL CALLS):
 ```csv
-entity_id,name,state,aliases,area,type,current_value,available_services
+entity_id,name,state,aliases,area,type,current_value,available_services{%- if exposed_entities and exposed_entities[0].labels is defined %},labels{%- endif %}
 {%- for entity in exposed_entities %}
 {%- set domain = entity.entity_id.split('.')[0] %}
 {%- set current_val = '' %}
@@ -875,7 +877,7 @@ entity_id,name,state,aliases,area,type,current_value,available_services
 {%- endif %}
 {{ entity.entity_id }},{{ entity.name }},{{ entity.state }},
 {{- entity.aliases | join('/') }},{{ area_name(entity.entity_id) | default('unknown') }},
-{{- domain }},{{ current_val }},{{ services }}
+{{- domain }},{{ current_val }},{{ services }}{%- if entity.labels is defined %},{{ entity.labels | join('/') }}{%- endif %}
 {%- endfor %}
 ```
 Now respond to the user's request:"""

--- a/custom_components/home_agent/context_manager.py
+++ b/custom_components/home_agent/context_manager.py
@@ -19,10 +19,12 @@ from .const import (
     CONF_CONTEXT_FORMAT,
     CONF_CONTEXT_MODE,
     CONF_DIRECT_ENTITIES,
+    CONF_PROMPT_INCLUDE_LABELS,
     CONTEXT_MODE_DIRECT,
     CONTEXT_MODE_VECTOR_DB,
     DEFAULT_CONTEXT_FORMAT,
     DEFAULT_CONTEXT_MODE,
+    DEFAULT_PROMPT_INCLUDE_LABELS,
     EVENT_CONTEXT_INJECTED,
     EVENT_CONTEXT_OPTIMIZED,
     MAX_CONTEXT_TOKENS,
@@ -138,6 +140,9 @@ class ContextManager:
         provider_config = {
             "entities": self.config.get(CONF_DIRECT_ENTITIES, []),
             "format": self.config.get(CONF_CONTEXT_FORMAT, DEFAULT_CONTEXT_FORMAT),
+            "include_labels": self.config.get(
+                CONF_PROMPT_INCLUDE_LABELS, DEFAULT_PROMPT_INCLUDE_LABELS
+            ),
         }
         return DirectContextProvider(self.hass, provider_config)
 

--- a/custom_components/home_agent/context_providers/direct.py
+++ b/custom_components/home_agent/context_providers/direct.py
@@ -49,6 +49,7 @@ class DirectContextProvider(ContextProvider):
         super().__init__(hass, config)
         self.entities_config = config.get("entities", [])
         self.format_type: Literal["json", "natural_language"] = config.get("format", "json")
+        self.include_labels = config.get("include_labels", False)
 
     async def get_context(self, user_input: str) -> str:
         """Get formatted context for configured entities.
@@ -122,7 +123,9 @@ class DirectContextProvider(ContextProvider):
             matching_entities = self._get_entities_matching_pattern(entity_id)
 
             for matched_entity_id in matching_entities:
-                state_data = self._get_entity_state(matched_entity_id, attributes_filter)
+                state_data = self._get_entity_state(
+                    matched_entity_id, attributes_filter, include_labels=self.include_labels
+                )
 
                 if state_data:
                     # Add available services for consistency with vector DB mode
@@ -147,7 +150,9 @@ class DirectContextProvider(ContextProvider):
         # Get all entities that should be exposed to conversation
         for state in self.hass.states.async_all():
             if async_should_expose(self.hass, ha_conversation.DOMAIN, state.entity_id):
-                state_data = self._get_entity_state(state.entity_id)
+                state_data = self._get_entity_state(
+                    state.entity_id, include_labels=self.include_labels
+                )
                 if state_data:
                     # Add available services for consistency with vector DB mode
                     state_data["available_services"] = self._get_entity_services(state.entity_id)

--- a/custom_components/home_agent/strings.json
+++ b/custom_components/home_agent/strings.json
@@ -275,10 +275,12 @@
         "description": "Configure the system prompt that guides the LLM's behavior.",
         "data": {
           "use_default_prompt": "Use Default System Prompt",
+          "prompt_include_labels": "Include Entity/Device Labels",
           "custom_prompt_additions": "Custom Prompt Additions"
         },
         "data_description": {
           "use_default_prompt": "Use Home Agent's built-in system prompt",
+          "prompt_include_labels": "Include entity and device labels in the system prompt for better context",
           "custom_prompt_additions": "Additional instructions to append to the system prompt"
         }
       },

--- a/custom_components/home_agent/translations/en.json
+++ b/custom_components/home_agent/translations/en.json
@@ -275,10 +275,12 @@
         "description": "Configure the system prompt that guides the LLM's behavior.",
         "data": {
           "use_default_prompt": "Use Default System Prompt",
+          "prompt_include_labels": "Include Entity/Device Labels",
           "custom_prompt_additions": "Custom Prompt Additions"
         },
         "data_description": {
           "use_default_prompt": "Use Home Agent's built-in system prompt",
+          "prompt_include_labels": "Include entity and device labels in the system prompt for better context",
           "custom_prompt_additions": "Additional instructions to append to the system prompt"
         }
       },


### PR DESCRIPTION
Changes Made:
1. Configuration Constants (const.py) Added CONF_PROMPT_INCLUDE_LABELS configuration key Added DEFAULT_PROMPT_INCLUDE_LABELS = False (disabled by default)
2. Configuration UI (config_flow.py) Added the new configuration option to the prompt settings form Imported the new constants
3. Translation Strings (strings.json and translations/en.json) Added UI label: "Include Entity/Device Labels"
Added description: "Include entity and device labels in the system prompt for better context"
4. Context Provider Base (context_providers/base.py) Modified _get_entity_state() to accept an include_labels parameter Added logic to fetch and include entity labels from the entity registry when enabled
5. Direct Context Provider (context_providers/direct.py) Updated to read the include_labels configuration
Passes the flag to _get_entity_state() calls
6. Context Manager (context_manager.py) Updated to pass the include_labels configuration to the direct context provider
7. Agent Core (agent/core.py) Modified get_exposed_entities() to include labels when the configuration flag is enabled Labels are fetched from the entity registry and added to the entity dictionary
8. System Prompt Template (const.py) Updated the CSV header to conditionally include a "labels" column Modified the CSV row template to include labels (joined with '/') when available How It Works:
Users can enable "Include Entity/Device Labels" in the System Prompt configuration section When enabled, the system will:
Fetch labels from Home Assistant's entity registry for each exposed entity Include them in the CSV format in the system prompt Display them as a comma-separated list (e.g., bedroom/lights/automation) The LLM can now use label information for better context understanding and more intelligent responses Example Output:
Without labels (default):

entity_id,name,state,aliases,area,type,current_value,available_services light.bedroom,Bedroom Light,on,,bedroom,light,75,turn_on,turn_off,toggle

With labels enabled:

entity_id,name,state,aliases,area,type,current_value,available_services,labels light.bedroom,Bedroom Light,on,,bedroom,light,75,turn_on,turn_off,toggle,bedroom/lights/automation

The feature is backward compatible and disabled by default to avoid adding unnecessary context for users who don't use labels.

Closes #11 