### PR TITLE
Fix: Tool result containing datetime causing exception

### DIFF
--- a/custom_components/home_agent/agent/core.py
+++ b/custom_components/home_agent/agent/core.py
@@ -94,6 +94,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -1169,12 +1170,17 @@ class HomeAgent(
                     messages.append(msg)
 
                 elif isinstance(content_item, conversation.ToolResultContent):
+                    def json_encoder(obj):
+                        if isinstance(obj, (datetime, date)):
+                            return obj.isoformat()
+                        raise TypeError ("Object of type %s is not JSON serializable" % type(obj))
+
                     messages.append(
                         {
                             "role": "tool",
                             "tool_call_id": content_item.tool_call_id,
                             "name": content_item.tool_name,
-                            "content": json.dumps(content_item.tool_result),
+                            "content": json.dumps(content_item.tool_result, default=json_encoder),
                         }
                     )
 


### PR DESCRIPTION
# Pull Request

## Description

### What does this PR do?

Fixes JSON serialisation on tool call results when the result data contains `date` or `datetime`.


### Why is this change needed?

Because `ha_query` with `{"entity_id": "someid"}` (returning all attributes) fails on attributes that are of type datetime.

## Related Issues

<!-- Link to related issues using the format below -->
Fixes #

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] Tests added/updated (if applicable)
- [ ] All tests pass locally
- [ ] Code formatted with `black` and `isort`
- [ ] Code linted with `flake8`, `pylint`, and `mypy` (no critical issues)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if applicable)

## Testing

### How was this tested?

Manual by modifying `core.py` after finding many exception in the log (and the inability to fetch all attributes, e.g. for a media_player where album and title is in the attributes).

### Test Coverage
<!-- If applicable, provide test coverage percentage or mention coverage changes -->
- Coverage: _%

## Additional Notes

<!-- Any additional information, screenshots, or context that reviewers should know -->


---

<!-- Please review CONTRIBUTING.md (if available) before submitting your PR -->
