### PR TITLE
Release v0.9.5

### DIFF
--- a/custom_components/home_agent/const.py
+++ b/custom_components/home_agent/const.py
@@ -5,7 +5,7 @@ from typing import Final
 # Domain and component info
 DOMAIN: Final = "home_agent"
 DEFAULT_NAME: Final = "Home Agent"
-VERSION: Final = "0.9.4"
+VERSION: Final = "0.9.5"
 
 # Configuration keys - LLM Configuration
 CONF_LLM_BASE_URL: Final = "llm_base_url"

--- a/custom_components/home_agent/context_providers/base.py
+++ b/custom_components/home_agent/context_providers/base.py
@@ -386,20 +386,22 @@ class ContextProvider(ABC):
             result["labels"] = labels
 
         # Get area_name from area registry
+        try:
+            entity_registry = er.async_get(self.hass)
+            area_registry = ar.async_get(self.hass)
+            device_registry = dr.async_get(self.hass)
 
-        entity_registry = er.async_get(self.hass)
-        area_registry = ar.async_get(self.hass)
-        device_registry = dr.async_get(self.hass)
-
-        if entity_entry := entity_registry.async_get(entity_id):
-            area_id = entity_entry.area_id
-            if not area_id and entity_entry.device_id:
-                device_entry = device_registry.async_get(entity_entry.device_id)
-                if device_entry:
-                    area_id = device_entry.area_id
-            if area_id:
-                if area := area_registry.async_get_area(area_id):
-                    result["Location"] = area.name
+            if entity_entry := entity_registry.async_get(entity_id):
+                area_id = entity_entry.area_id
+                if not area_id and entity_entry.device_id:
+                    device_entry = device_registry.async_get(entity_entry.device_id)
+                    if device_entry:
+                        area_id = device_entry.area_id
+                if area_id:
+                    if area := area_registry.async_get_area(area_id):
+                        result["Location"] = area.name
+        except (AttributeError, RuntimeError):
+            pass
 
         # Include filtered attributes or all attributes, ensuring JSON serializability
         if attribute_filter is not None:

--- a/custom_components/home_agent/manifest.json
+++ b/custom_components/home_agent/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/aradlein/hass-agent-llm/issues",
   "requirements": ["aiohttp>=3.9.0", "chromadb-client==1.5.3"],
-  "version": "0.9.4"
+  "version": "0.9.5"
 }

--- a/custom_components/home_agent/vector_db_manager.py
+++ b/custom_components/home_agent/vector_db_manager.py
@@ -423,6 +423,17 @@ class VectorDBManager:
         if not entity_id or self._should_skip_entity(entity_id):
             return
 
+        # Skip reindex if state and attributes haven't changed
+        old_state = event.data.get("old_state")
+        new_state = event.data.get("new_state")
+        if (
+            old_state is not None
+            and new_state is not None
+            and old_state.state == new_state.state
+            and old_state.attributes == new_state.attributes
+        ):
+            return
+
         # Record pending reindex (deduplicates rapid changes for same entity)
         self._pending_reindex[entity_id] = asyncio.get_event_loop().time()
 

--- a/tests/integration/test_real_vector_db.py
+++ b/tests/integration/test_real_vector_db.py
@@ -548,3 +548,283 @@ class TestRealVectorDB:
 
         finally:
             await manager.async_shutdown()
+
+
+@pytest.mark.integration
+@pytest.mark.requires_chromadb
+@pytest.mark.requires_embedding
+@pytest.mark.usefixtures("socket_enabled")
+class TestAreaLookupEntityIndexing:
+    """Integration tests for area resolution during entity indexing.
+
+    These tests verify that area names are correctly included in indexed entity
+    text when using the entity registry → device registry → area registry chain.
+    They use real ChromaDB and embeddings to exercise the full indexing pipeline.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def skip_without_real_services(self, chromadb_config, embedding_config):
+        """Skip when real services are unavailable."""
+        from tests.integration.health import check_chromadb_health, check_embedding_health
+
+        chromadb_healthy = await check_chromadb_health(
+            chromadb_config["host"], chromadb_config["port"]
+        )
+        embedding_healthy = await check_embedding_health(embedding_config["base_url"])
+
+        if not chromadb_healthy or not embedding_healthy:
+            pytest.skip(
+                "Real ChromaDB and Embedding services required. "
+                f"ChromaDB: {'ok' if chromadb_healthy else 'unavailable'}. "
+                f"Embedding: {'ok' if embedding_healthy else 'unavailable'}."
+            )
+
+    def _make_registry_mocks(self, entity_area_id=None, device_area_id=None, has_device=True):
+        """Build entity/device/area registry mocks for a single entity."""
+        from unittest.mock import MagicMock
+
+        mock_entity_entry = MagicMock()
+        mock_entity_entry.area_id = entity_area_id
+        mock_entity_entry.device_id = "device_abc" if has_device else None
+        mock_entity_entry.aliases = []
+
+        mock_device_entry = MagicMock()
+        mock_device_entry.area_id = device_area_id
+
+        def area_lookup(area_id):
+            area = MagicMock()
+            area.name = {
+                "bedroom_area": "Bedroom",
+                "kitchen_area": "Kitchen",
+            }.get(area_id, f"Area_{area_id}")
+            return area
+
+        mock_er = MagicMock()
+        mock_er.async_get.return_value = mock_entity_entry
+
+        mock_ar = MagicMock()
+        mock_ar.async_get_area.side_effect = area_lookup
+
+        mock_dr = MagicMock()
+        mock_dr.async_get.return_value = mock_device_entry if has_device else None
+
+        return mock_er, mock_ar, mock_dr
+
+    @pytest.mark.asyncio
+    async def test_entity_area_included_in_indexed_document(
+        self,
+        mock_hass_integration,
+        embedding_config,
+        test_collection_name,
+    ):
+        """Entity-level area_id is reflected in the ChromaDB document text.
+
+        Verifies the full pipeline:
+        entity registry (area_id=bedroom_area) → area name 'Bedroom' → document text.
+        """
+        from unittest.mock import patch
+
+        from homeassistant.core import State
+
+        config = {
+            "vector_db_host": embedding_config["host"],
+            "vector_db_port": embedding_config["port"],
+            "vector_db_collection": test_collection_name,
+            "vector_db_embedding_model": embedding_config["model"],
+            "vector_db_embedding_provider": embedding_config["provider"],
+            "vector_db_embedding_base_url": embedding_config["base_url"],
+        }
+
+        state = State("light.bedroom_lamp", "on", {"friendly_name": "Bedroom Lamp"})
+        mock_hass_integration.states.get.side_effect = (
+            lambda eid: state if eid == "light.bedroom_lamp" else None
+        )
+        mock_hass_integration.states.async_all.return_value = [state]
+
+        mock_er, mock_ar, mock_dr = self._make_registry_mocks(
+            entity_area_id="bedroom_area",
+            device_area_id=None,
+        )
+
+        manager = VectorDBManager(mock_hass_integration, config)
+        try:
+            await manager._ensure_initialized()
+
+            with (
+                patch(
+                    "custom_components.home_agent.vector_db_manager.er.async_get",
+                    return_value=mock_er,
+                ),
+                patch(
+                    "custom_components.home_agent.vector_db_manager.ar.async_get",
+                    return_value=mock_ar,
+                ),
+                patch(
+                    "custom_components.home_agent.vector_db_manager.dr.async_get",
+                    return_value=mock_dr,
+                ),
+            ):
+                await manager.async_index_entity("light.bedroom_lamp")
+
+            collection = manager._collection
+            result = await mock_hass_integration.async_add_executor_job(
+                lambda: collection.get(ids=["light.bedroom_lamp"])
+            )
+
+            assert len(result["ids"]) == 1
+            document = result["documents"][0]
+            assert "Bedroom" in document, f"Expected 'Bedroom' in document, got: {document}"
+            assert "Location:" in document
+
+        finally:
+            await manager.async_shutdown()
+
+    @pytest.mark.asyncio
+    async def test_device_area_fallback_in_indexed_document(
+        self,
+        mock_hass_integration,
+        embedding_config,
+        test_collection_name,
+    ):
+        """Device area is used when entity has no direct area_id.
+
+        Verifies:
+        - entity_entry.area_id = None
+        - device_entry.area_id = 'kitchen_area'
+        - Document contains 'Kitchen'
+        """
+        from unittest.mock import patch
+
+        from homeassistant.core import State
+
+        config = {
+            "vector_db_host": embedding_config["host"],
+            "vector_db_port": embedding_config["port"],
+            "vector_db_collection": test_collection_name,
+            "vector_db_embedding_model": embedding_config["model"],
+            "vector_db_embedding_provider": embedding_config["provider"],
+            "vector_db_embedding_base_url": embedding_config["base_url"],
+        }
+
+        state = State(
+            "sensor.kitchen_temp",
+            "22",
+            {"friendly_name": "Kitchen Temperature", "unit_of_measurement": "°C"},
+        )
+        mock_hass_integration.states.get.side_effect = (
+            lambda eid: state if eid == "sensor.kitchen_temp" else None
+        )
+        mock_hass_integration.states.async_all.return_value = [state]
+
+        # Entity has NO direct area; its device has a kitchen area
+        mock_er, mock_ar, mock_dr = self._make_registry_mocks(
+            entity_area_id=None,
+            device_area_id="kitchen_area",
+            has_device=True,
+        )
+
+        manager = VectorDBManager(mock_hass_integration, config)
+        try:
+            await manager._ensure_initialized()
+
+            with (
+                patch(
+                    "custom_components.home_agent.vector_db_manager.er.async_get",
+                    return_value=mock_er,
+                ),
+                patch(
+                    "custom_components.home_agent.vector_db_manager.ar.async_get",
+                    return_value=mock_ar,
+                ),
+                patch(
+                    "custom_components.home_agent.vector_db_manager.dr.async_get",
+                    return_value=mock_dr,
+                ),
+            ):
+                await manager.async_index_entity("sensor.kitchen_temp")
+
+            collection = manager._collection
+            result = await mock_hass_integration.async_add_executor_job(
+                lambda: collection.get(ids=["sensor.kitchen_temp"])
+            )
+
+            assert len(result["ids"]) == 1
+            document = result["documents"][0]
+            assert "Kitchen" in document, f"Expected 'Kitchen' in document, got: {document}"
+
+        finally:
+            await manager.async_shutdown()
+
+    @pytest.mark.asyncio
+    async def test_entity_area_takes_priority_over_device_area_in_indexed_document(
+        self,
+        mock_hass_integration,
+        embedding_config,
+        test_collection_name,
+    ):
+        """Entity area_id takes priority over device area in the indexed document.
+
+        Both entity and device have areas. Only the entity area should appear.
+        """
+        from unittest.mock import patch
+
+        from homeassistant.core import State
+
+        config = {
+            "vector_db_host": embedding_config["host"],
+            "vector_db_port": embedding_config["port"],
+            "vector_db_collection": test_collection_name,
+            "vector_db_embedding_model": embedding_config["model"],
+            "vector_db_embedding_provider": embedding_config["provider"],
+            "vector_db_embedding_base_url": embedding_config["base_url"],
+        }
+
+        state = State("light.office_desk", "on", {"friendly_name": "Office Desk Light"})
+        mock_hass_integration.states.get.side_effect = (
+            lambda eid: state if eid == "light.office_desk" else None
+        )
+        mock_hass_integration.states.async_all.return_value = [state]
+
+        # Entity has 'bedroom_area', device has 'kitchen_area' — entity should win
+        mock_er, mock_ar, mock_dr = self._make_registry_mocks(
+            entity_area_id="bedroom_area",
+            device_area_id="kitchen_area",
+            has_device=True,
+        )
+
+        manager = VectorDBManager(mock_hass_integration, config)
+        try:
+            await manager._ensure_initialized()
+
+            with (
+                patch(
+                    "custom_components.home_agent.vector_db_manager.er.async_get",
+                    return_value=mock_er,
+                ),
+                patch(
+                    "custom_components.home_agent.vector_db_manager.ar.async_get",
+                    return_value=mock_ar,
+                ),
+                patch(
+                    "custom_components.home_agent.vector_db_manager.dr.async_get",
+                    return_value=mock_dr,
+                ),
+            ):
+                await manager.async_index_entity("light.office_desk")
+
+            collection = manager._collection
+            result = await mock_hass_integration.async_add_executor_job(
+                lambda: collection.get(ids=["light.office_desk"])
+            )
+
+            assert len(result["ids"]) == 1
+            document = result["documents"][0]
+            assert "Bedroom" in document, (
+                f"Expected entity area 'Bedroom' in document, got: {document}"
+            )
+            assert "Kitchen" not in document, (
+                f"'Kitchen' (device area) should not appear, got: {document}"
+            )
+
+        finally:
+            await manager.async_shutdown()

--- a/tests/unit/test_agent_streaming.py
+++ b/tests/unit/test_agent_streaming.py
@@ -2003,3 +2003,111 @@ class TestStreamingPreprocessing:
             assert (
                 user_content == "Hello world\n/no_think"
             ), f"Expected 'Hello world\\n/no_think', got: {repr(user_content)}"
+
+
+class TestToolResultDatetimeSerialization:
+    """Test that datetime/date objects in tool results are serialized correctly."""
+
+    @pytest.mark.asyncio
+    async def test_tool_result_with_datetime_does_not_raise(self, agent, mock_hass):
+        """Test that a tool result containing a datetime value is JSON-serialized without error."""
+        import json
+        from datetime import date, datetime
+
+        from homeassistant.components.conversation import AssistantContent, ToolResultContent
+        from homeassistant.helpers.llm import ToolInput
+
+        agent.config[CONF_STREAMING_ENABLED] = True
+
+        mock_input = MagicMock(spec=ha_conversation.ConversationInput)
+        mock_input.text = "When is the next event?"
+        mock_input.conversation_id = "test-conv"
+        mock_input.language = "en"
+        mock_input.context = MagicMock()
+        mock_input.context.user_id = "test-user"
+        mock_input.device_id = None
+
+        # Leave unresponded_tool_results as a MagicMock (truthy) so the loop
+        # can iterate a second time after processing the tool result.
+        mock_chat_log_instance = MagicMock()
+        mock_chat_log_instance.delta_listener = MagicMock()
+
+        mock_tool_call = ToolInput(
+            id="call_dt",
+            tool_name="ha_query",
+            tool_args={"query": "next event"},
+        )
+
+        # Tool result contains datetime and date objects (e.g. media_player attributes)
+        tool_result_with_datetimes = {
+            "state": "playing",
+            "last_updated": datetime(2026, 5, 10, 12, 0, 0),
+            "scheduled_date": date(2026, 5, 11),
+        }
+
+        stream_call_count = 0
+        captured_messages = []
+
+        # Two-stream setup: iteration 1 yields tool call + result;
+        # iteration 2 yields the final answer (no tool calls → loop breaks).
+        async def mock_content_stream(*args, **kwargs):
+            nonlocal stream_call_count
+            stream_call_count += 1
+            if stream_call_count == 1:
+                yield AssistantContent(
+                    agent_id="home_agent",
+                    content=None,
+                    tool_calls=[mock_tool_call],
+                )
+                yield ToolResultContent(
+                    agent_id="home_agent",
+                    tool_call_id="call_dt",
+                    tool_name="ha_query",
+                    tool_result=tool_result_with_datetimes,
+                )
+            else:
+                yield AssistantContent(
+                    agent_id="home_agent",
+                    content="The event is tomorrow.",
+                    tool_calls=None,
+                )
+
+        mock_chat_log_instance.async_add_delta_content_stream = mock_content_stream
+
+        mock_result = MagicMock(spec=ha_conversation.ConversationResult)
+        mock_result.conversation_id = "test-conv"
+
+        def capture_llm_messages(messages):
+            captured_messages.append([m.copy() for m in messages])
+
+            async def mock_stream():
+                yield "data: {}"
+
+            return mock_stream()
+
+        with (
+            patch(
+                "homeassistant.components.conversation.chat_log.current_chat_log"
+            ) as mock_chat_log,
+            patch.object(agent, "_call_llm_streaming", side_effect=capture_llm_messages),
+            patch(
+                "homeassistant.components.conversation.async_get_result_from_chat_log",
+                return_value=mock_result,
+            ),
+        ):
+            mock_chat_log.get.return_value = mock_chat_log_instance
+
+            # Must not raise TypeError for datetime serialization
+            await agent.async_process(mock_input)
+
+        assert stream_call_count == 2, "Expected two loop iterations"
+
+        # The second LLM call receives the messages INCLUDING the tool result.
+        # Verify datetime values were serialized to ISO strings.
+        tool_messages = [m for m in captured_messages[1] if m.get("role") == "tool"]
+        assert len(tool_messages) >= 1, "Expected a tool message in the second LLM call"
+
+        tool_content = json.loads(tool_messages[0]["content"])
+        assert tool_content["state"] == "playing"
+        assert tool_content["last_updated"] == "2026-05-10T12:00:00"
+        assert tool_content["scheduled_date"] == "2026-05-11"

--- a/tests/unit/test_context_providers/test_base.py
+++ b/tests/unit/test_context_providers/test_base.py
@@ -4,7 +4,7 @@ This module tests the abstract base class for context providers,
 including helper methods and the abstract interface.
 """
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from homeassistant.core import State
@@ -18,6 +18,37 @@ class ConcreteContextProvider(ContextProvider):
     async def get_context(self, user_input: str) -> str:
         """Concrete implementation of get_context."""
         return f"Context for: {user_input}"
+
+
+@pytest.fixture(autouse=True)
+def stub_area_registries():
+    """Stub out entity/device/area registry calls for all tests in this module.
+
+    The area-lookup code added in base.py calls er/ar/dr.async_get(hass).
+    Tests that don't care about area resolution get a no-op stub so they
+    don't blow up on the real HA registry internals.  Tests that DO care
+    about area resolution override these stubs in their own patch contexts.
+    """
+    mock_er = Mock()
+    mock_er.async_get.return_value = None  # entity not in registry → no area
+    mock_ar = Mock()
+    mock_dr = Mock()
+
+    with (
+        patch(
+            "custom_components.home_agent.context_providers.base.er.async_get",
+            return_value=mock_er,
+        ),
+        patch(
+            "custom_components.home_agent.context_providers.base.ar.async_get",
+            return_value=mock_ar,
+        ),
+        patch(
+            "custom_components.home_agent.context_providers.base.dr.async_get",
+            return_value=mock_dr,
+        ),
+    ):
+        yield
 
 
 class TestContextProviderInit:
@@ -835,4 +866,157 @@ class TestGetEntityStateWithLabels:
             result = provider._get_entity_state("cover.garage", include_labels=False)
 
         assert result is not None
+
+
+class TestGetEntityStateAreaLookup:
+    """Tests for area resolution via entity/device/area registries."""
+
+    def _make_provider(self, mock_hass):
+        class ConcreteProvider(ContextProvider):
+            async def get_context(self, user_input: str) -> str:
+                return ""
+
+        return ConcreteProvider(mock_hass, {})
+
+    def test_location_from_entity_area_id(self, mock_hass):
+        """Entity-level area_id is resolved to Location in state result."""
+        from unittest.mock import patch
+
+        provider = self._make_provider(mock_hass)
+        state = Mock(spec=State)
+        state.entity_id = "light.bedroom"
+        state.state = "on"
+        state.attributes = {"friendly_name": "Bedroom Light"}
+        mock_hass.states.get.return_value = state
+
+        mock_entity_entry = Mock()
+        mock_entity_entry.aliases = []
+        mock_entity_entry.labels = set()
+        mock_entity_entry.area_id = "bedroom"
+        mock_entity_entry.device_id = None
+
+        mock_area = Mock()
+        mock_area.name = "Bedroom"
+
+        mock_er = Mock()
+        mock_er.async_get.return_value = mock_entity_entry
+        mock_ar = Mock()
+        mock_ar.async_get_area.return_value = mock_area
+        mock_dr = Mock()
+
+        with (
+            patch("custom_components.home_agent.context_providers.base.er.async_get", return_value=mock_er),
+            patch("custom_components.home_agent.context_providers.base.ar.async_get", return_value=mock_ar),
+            patch("custom_components.home_agent.context_providers.base.dr.async_get", return_value=mock_dr),
+        ):
+            result = provider._get_entity_state("light.bedroom")
+
+        assert result is not None
+        assert result.get("Location") == "Bedroom"
+
+    def test_location_falls_back_to_device_area(self, mock_hass):
+        """Device area is used when entity has no direct area_id."""
+        from unittest.mock import patch
+
+        provider = self._make_provider(mock_hass)
+        state = Mock(spec=State)
+        state.entity_id = "sensor.kitchen_temp"
+        state.state = "22"
+        state.attributes = {}
+        mock_hass.states.get.return_value = state
+
+        mock_entity_entry = Mock()
+        mock_entity_entry.aliases = []
+        mock_entity_entry.labels = set()
+        mock_entity_entry.area_id = None
+        mock_entity_entry.device_id = "device_xyz"
+
+        mock_device_entry = Mock()
+        mock_device_entry.area_id = "kitchen"
+
+        mock_area = Mock()
+        mock_area.name = "Kitchen"
+
+        mock_er = Mock()
+        mock_er.async_get.return_value = mock_entity_entry
+        mock_ar = Mock()
+        mock_ar.async_get_area.return_value = mock_area
+        mock_dr = Mock()
+        mock_dr.async_get.return_value = mock_device_entry
+
+        with (
+            patch("custom_components.home_agent.context_providers.base.er.async_get", return_value=mock_er),
+            patch("custom_components.home_agent.context_providers.base.ar.async_get", return_value=mock_ar),
+            patch("custom_components.home_agent.context_providers.base.dr.async_get", return_value=mock_dr),
+        ):
+            result = provider._get_entity_state("sensor.kitchen_temp")
+
+        assert result is not None
+        assert result.get("Location") == "Kitchen"
+
+    def test_entity_area_takes_priority_over_device_area(self, mock_hass):
+        """Entity-level area_id takes priority over device area."""
+        from unittest.mock import patch
+
+        provider = self._make_provider(mock_hass)
+        state = Mock(spec=State)
+        state.entity_id = "light.office"
+        state.state = "on"
+        state.attributes = {}
+        mock_hass.states.get.return_value = state
+
+        mock_entity_entry = Mock()
+        mock_entity_entry.aliases = []
+        mock_entity_entry.labels = set()
+        mock_entity_entry.area_id = "office_area"
+        mock_entity_entry.device_id = "device_abc"
+
+        mock_device_entry = Mock()
+        mock_device_entry.area_id = "garage_area"
+
+        def area_lookup(area_id):
+            a = Mock()
+            a.name = "Office" if area_id == "office_area" else "Garage"
+            return a
+
+        mock_er = Mock()
+        mock_er.async_get.return_value = mock_entity_entry
+        mock_ar = Mock()
+        mock_ar.async_get_area.side_effect = area_lookup
+        mock_dr = Mock()
+        mock_dr.async_get.return_value = mock_device_entry
+
+        with (
+            patch("custom_components.home_agent.context_providers.base.er.async_get", return_value=mock_er),
+            patch("custom_components.home_agent.context_providers.base.ar.async_get", return_value=mock_ar),
+            patch("custom_components.home_agent.context_providers.base.dr.async_get", return_value=mock_dr),
+        ):
+            result = provider._get_entity_state("light.office")
+
+        assert result is not None
+        assert result.get("Location") == "Office"
+
+    def test_no_location_when_entity_not_in_registry(self, mock_hass):
+        """No Location is set when entity is not in the entity registry."""
+        from unittest.mock import patch
+
+        provider = self._make_provider(mock_hass)
+        state = Mock(spec=State)
+        state.entity_id = "sensor.unknown"
+        state.state = "99"
+        state.attributes = {}
+        mock_hass.states.get.return_value = state
+
+        mock_er = Mock()
+        mock_er.async_get.return_value = None
+
+        with (
+            patch("custom_components.home_agent.context_providers.base.er.async_get", return_value=mock_er),
+            patch("custom_components.home_agent.context_providers.base.ar.async_get", return_value=Mock()),
+            patch("custom_components.home_agent.context_providers.base.dr.async_get", return_value=Mock()),
+        ):
+            result = provider._get_entity_state("sensor.unknown")
+
+        assert result is not None
+        assert "Location" not in result
         assert "labels" not in result  # Labels should NOT be included

--- a/tests/unit/test_vector_db_manager.py
+++ b/tests/unit/test_vector_db_manager.py
@@ -1162,3 +1162,330 @@ async def test_async_run_maintenance_handles_empty_result(
 
         # Should not raise
         await manager._async_run_maintenance(None)
+
+
+# ---------------------------------------------------------------------------
+# Tests for unchanged-state skip in _async_handle_state_change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_change_skipped_when_state_and_attributes_unchanged(
+    mock_hass, mock_chromadb, vector_db_config, mock_async_should_expose
+):
+    """Test that reindex is skipped when old and new state are identical."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+
+        with patch.object(manager, "async_index_entity", AsyncMock()) as mock_index:
+            old_state = State("light.living_room", "on", {"brightness": 255})
+            new_state = State("light.living_room", "on", {"brightness": 255})
+
+            event = Event(
+                EVENT_STATE_CHANGED,
+                {
+                    "entity_id": "light.living_room",
+                    "old_state": old_state,
+                    "new_state": new_state,
+                },
+            )
+
+            with patch(
+                "custom_components.home_agent.vector_db_manager.async_should_expose",
+                mock_async_should_expose,
+            ):
+                manager._async_handle_state_change(event)
+                await asyncio.sleep(0.1)
+
+            mock_index.assert_not_called()
+            assert "light.living_room" not in manager._pending_reindex
+
+
+@pytest.mark.asyncio
+async def test_state_change_triggers_reindex_when_state_value_changes(
+    mock_hass, mock_chromadb, vector_db_config, mock_async_should_expose
+):
+    """Test that reindex runs when state value changes."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        await manager._ensure_initialized()
+
+        with (
+            patch.object(manager, "async_index_entity", AsyncMock()) as mock_index,
+            patch(
+                "custom_components.home_agent.vector_db_manager.async_should_expose",
+                mock_async_should_expose,
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.REINDEX_DEBOUNCE_DELAY", 0.05
+            ),
+        ):
+            old_state = State("light.living_room", "off", {"brightness": 0})
+            new_state = State("light.living_room", "on", {"brightness": 255})
+
+            event = Event(
+                EVENT_STATE_CHANGED,
+                {
+                    "entity_id": "light.living_room",
+                    "old_state": old_state,
+                    "new_state": new_state,
+                },
+            )
+
+            manager._async_handle_state_change(event)
+            await asyncio.sleep(0.2)
+
+        mock_index.assert_called_once_with("light.living_room")
+
+
+@pytest.mark.asyncio
+async def test_state_change_triggers_reindex_when_attributes_change(
+    mock_hass, mock_chromadb, vector_db_config, mock_async_should_expose
+):
+    """Test that reindex runs when attributes change even if state value is same."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        await manager._ensure_initialized()
+
+        with (
+            patch.object(manager, "async_index_entity", AsyncMock()) as mock_index,
+            patch(
+                "custom_components.home_agent.vector_db_manager.async_should_expose",
+                mock_async_should_expose,
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.REINDEX_DEBOUNCE_DELAY", 0.05
+            ),
+        ):
+            old_state = State("light.living_room", "on", {"brightness": 128})
+            new_state = State("light.living_room", "on", {"brightness": 255})
+
+            event = Event(
+                EVENT_STATE_CHANGED,
+                {
+                    "entity_id": "light.living_room",
+                    "old_state": old_state,
+                    "new_state": new_state,
+                },
+            )
+
+            manager._async_handle_state_change(event)
+            await asyncio.sleep(0.2)
+
+        mock_index.assert_called_once_with("light.living_room")
+
+
+@pytest.mark.asyncio
+async def test_state_change_triggers_reindex_for_new_entity(
+    mock_hass, mock_chromadb, vector_db_config, mock_async_should_expose
+):
+    """Test that reindex runs when old_state is None (entity first appearance)."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        await manager._ensure_initialized()
+
+        with (
+            patch.object(manager, "async_index_entity", AsyncMock()) as mock_index,
+            patch(
+                "custom_components.home_agent.vector_db_manager.async_should_expose",
+                mock_async_should_expose,
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.REINDEX_DEBOUNCE_DELAY", 0.05
+            ),
+        ):
+            new_state = State("light.living_room", "on", {})
+            event = Event(
+                EVENT_STATE_CHANGED,
+                {
+                    "entity_id": "light.living_room",
+                    "old_state": None,
+                    "new_state": new_state,
+                },
+            )
+
+            manager._async_handle_state_change(event)
+            await asyncio.sleep(0.2)
+
+        mock_index.assert_called_once_with("light.living_room")
+
+
+# ---------------------------------------------------------------------------
+# Tests for area/aliases in _create_entity_text (VectorDBManager)
+# ---------------------------------------------------------------------------
+
+
+def test_create_entity_text_includes_area_from_entity_registry(
+    mock_hass, mock_chromadb, vector_db_config
+):
+    """Test that entity-level area_id is used in entity text."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        state = State("light.living_room", "on", {"friendly_name": "Living Room Light"})
+
+        mock_entity_entry = MagicMock()
+        mock_entity_entry.area_id = "living_room"
+        mock_entity_entry.device_id = None
+        mock_entity_entry.aliases = []
+
+        mock_area = MagicMock()
+        mock_area.name = "Living Room"
+
+        with (
+            patch(
+                "custom_components.home_agent.vector_db_manager.er.async_get",
+                return_value=MagicMock(async_get=MagicMock(return_value=mock_entity_entry)),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.ar.async_get",
+                return_value=MagicMock(async_get_area=MagicMock(return_value=mock_area)),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.dr.async_get",
+                return_value=MagicMock(),
+            ),
+        ):
+            text = manager._create_entity_text(state)
+
+        assert "Location: Living Room" in text
+
+
+def test_create_entity_text_falls_back_to_device_area(
+    mock_hass, mock_chromadb, vector_db_config
+):
+    """Test that device area is used when entity has no direct area_id."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        state = State("light.living_room", "on", {"friendly_name": "Living Room Light"})
+
+        mock_entity_entry = MagicMock()
+        mock_entity_entry.area_id = None
+        mock_entity_entry.device_id = "device_abc"
+        mock_entity_entry.aliases = []
+
+        mock_device_entry = MagicMock()
+        mock_device_entry.area_id = "kitchen"
+
+        mock_area = MagicMock()
+        mock_area.name = "Kitchen"
+
+        with (
+            patch(
+                "custom_components.home_agent.vector_db_manager.er.async_get",
+                return_value=MagicMock(async_get=MagicMock(return_value=mock_entity_entry)),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.ar.async_get",
+                return_value=MagicMock(async_get_area=MagicMock(return_value=mock_area)),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.dr.async_get",
+                return_value=MagicMock(async_get=MagicMock(return_value=mock_device_entry)),
+            ),
+        ):
+            text = manager._create_entity_text(state)
+
+        assert "Location: Kitchen" in text
+
+
+def test_create_entity_text_no_area_when_entity_has_no_device(
+    mock_hass, mock_chromadb, vector_db_config
+):
+    """Test that no Location is included for entities with no device and no area_id."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        state = State("input_boolean.test", "on", {"friendly_name": "Test Helper"})
+
+        mock_entity_entry = MagicMock()
+        mock_entity_entry.area_id = None
+        mock_entity_entry.device_id = None
+        mock_entity_entry.aliases = []
+
+        with (
+            patch(
+                "custom_components.home_agent.vector_db_manager.er.async_get",
+                return_value=MagicMock(async_get=MagicMock(return_value=mock_entity_entry)),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.ar.async_get",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.dr.async_get",
+                return_value=MagicMock(),
+            ),
+        ):
+            text = manager._create_entity_text(state)
+
+        assert "Location:" not in text
+
+
+def test_create_entity_text_entity_area_takes_priority_over_device_area(
+    mock_hass, mock_chromadb, vector_db_config
+):
+    """Test that entity-level area_id takes priority over device area."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        state = State("light.bedroom", "on", {"friendly_name": "Bedroom Light"})
+
+        mock_entity_entry = MagicMock()
+        mock_entity_entry.area_id = "bedroom_area"
+        mock_entity_entry.device_id = "device_abc"
+        mock_entity_entry.aliases = []
+
+        mock_device_entry = MagicMock()
+        mock_device_entry.area_id = "living_room_area"
+
+        def area_lookup(area_id):
+            area = MagicMock()
+            area.name = "Bedroom" if area_id == "bedroom_area" else "Living Room"
+            return area
+
+        with (
+            patch(
+                "custom_components.home_agent.vector_db_manager.er.async_get",
+                return_value=MagicMock(async_get=MagicMock(return_value=mock_entity_entry)),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.ar.async_get",
+                return_value=MagicMock(async_get_area=area_lookup),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.dr.async_get",
+                return_value=MagicMock(async_get=MagicMock(return_value=mock_device_entry)),
+            ),
+        ):
+            text = manager._create_entity_text(state)
+
+        assert "Location: Bedroom" in text
+        assert "Living Room" not in text
+
+
+def test_create_entity_text_includes_aliases(mock_hass, mock_chromadb, vector_db_config):
+    """Test that entity aliases are included in entity text."""
+    with patch("custom_components.home_agent.vector_db_manager.CHROMADB_AVAILABLE", True):
+        manager = VectorDBManager(mock_hass, vector_db_config)
+        state = State("light.living_room", "on", {"friendly_name": "Living Room Light"})
+
+        mock_entity_entry = MagicMock()
+        mock_entity_entry.area_id = None
+        mock_entity_entry.device_id = None
+        mock_entity_entry.aliases = ["lounge light", "main light"]
+
+        with (
+            patch(
+                "custom_components.home_agent.vector_db_manager.er.async_get",
+                return_value=MagicMock(async_get=MagicMock(return_value=mock_entity_entry)),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.ar.async_get",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "custom_components.home_agent.vector_db_manager.dr.async_get",
+                return_value=MagicMock(),
+            ),
+        ):
+            text = manager._create_entity_text(state)
+
+        assert "Aliases: lounge light, main light" in text


### PR DESCRIPTION
## Release v0.9.5

### Changelog
- fix: skip vector reindex when entity state and attributes unchanged
- fix: add default=str to json.dumps in vector_db context provider
- fix: handle datetime serialization in tool results
- fix: check entity area_id before falling back to device area
- fix: use entity/device registry for area lookup instead of state.attributes
- docs: Update README for v0.9.4 release with changelog

### Post-Merge Steps
After merging this PR, the release tag and GitHub release will be created automatically:
- Tag: `v0.9.5`
- Pre-release: no