### PR TITLE
fix(memory): unwrap double-nested external-LLM extraction result

### DIFF
--- a/custom_components/home_agent/agent/memory_extraction.py
+++ b/custom_components/home_agent/agent/memory_extraction.py
@@ -663,7 +663,14 @@ Return ONLY valid JSON, no other text:
                     )
                     return
 
+                # tool_handler.execute_tool wraps the tool's return as
+                # {"success", "result": <tool.execute()>}, and query_external_llm's
+                # own execute() ALSO returns an {"success", "result": text, "error"}
+                # envelope — so result["result"] is that inner dict, not the text.
+                # Unwrap one level when present; tolerate a plain string too.
                 extraction_result = result.get("result", "[]")
+                if isinstance(extraction_result, dict):
+                    extraction_result = extraction_result.get("result", "[]")
 
             else:
                 # Use local/primary LLM

--- a/tests/unit/test_memory_extraction.py
+++ b/tests/unit/test_memory_extraction.py
@@ -615,8 +615,16 @@ class TestExtractAndStoreMemories:
             ]
         )
 
+        # execute_tool wraps the tool's return as {success, result: <tool.execute()>},
+        # and query_external_llm.execute() itself returns an {success, result, error}
+        # envelope — so the result is DOUBLE-nested. Mock that real shape so the
+        # unwrap in _extract_and_store_memories is exercised (without it, the inner
+        # dict reaches strip_thinking_blocks and the extraction silently stores 0).
         home_agent.tool_handler.execute_tool = AsyncMock(
-            return_value={"success": True, "result": extraction_result}
+            return_value={
+                "success": True,
+                "result": {"success": True, "result": extraction_result, "error": None},
+            }
         )
 
         await home_agent._extract_and_store_memories("conv_123", "user msg", "assistant msg", [])
@@ -627,6 +635,8 @@ class TestExtractAndStoreMemories:
         assert call_args[1]["tool_name"] == "query_external_llm"
         assert call_args[1]["conversation_id"] == "conv_123"
         assert isinstance(call_args[1]["parameters"]["prompt"], str)
+        # The double-nested result was unwrapped, parsed, and stored.
+        mock_memory_manager.add_memory.assert_called_once()
 
         # Verify memory was stored
         mock_memory_manager.add_memory.assert_called_once()


### PR DESCRIPTION
### Problem
With `memory_extraction_llm="external"`, `_extract_and_store_memories` reads the `query_external_llm` result as `result["result"]`. But `tool_handler.execute_tool` wraps a tool's return as `{success, result: <tool.execute()>}`, and `query_external_llm.execute()` itself already returns an `{success, result, error}` envelope — so `result["result"]` is that **inner dict**, not the extraction text.

The dict then reaches `strip_thinking_blocks(...)` (a regex call), raising `expected string or bytes-like object, got 'dict'`, which `_extract_and_store_memories` catches and logs as `Error parsing and storing memories` — silently storing **0** memories. It stays latent because the external-extraction path only runs when the external LLM is enabled.

### Fix
Unwrap one level when the result is a dict (tolerating a plain string too). The external-extraction unit test now mocks the real double-nested shape and asserts a memory is stored.

### Tests
`tests/unit/test_memory_extraction.py` — 31 passed.