### PR TITLE
fix(tools): refresh exposed-entity allow-list each turn (cold-boot race)

### DIFF
--- a/custom_components/home_agent/agent/core.py
+++ b/custom_components/home_agent/agent/core.py
@@ -286,6 +286,12 @@ class HomeAgent(
             # Ensure tools are registered (lazy initialization)
             self._ensure_tools_registered()
 
+            # Refresh the exposed-entity allow-list from HA's current exposure
+            # settings every turn, so entities discovered after the agent first
+            # initialised (cold-boot MQTT/Zigbee race) become controllable
+            # instead of staying frozen out of the initial snapshot.
+            self._refresh_exposed_entities()
+
             # Check if we can stream
             if self._can_stream():
                 try:
@@ -430,31 +436,60 @@ class HomeAgent(
                 conversation_id=user_input.conversation_id,
             )
 
-    def _register_tools(self) -> None:
-        """Register core Home Assistant tools."""
-        # Get exposed entities from voice assistant settings
-        # Use async_should_expose to respect Home Assistant's exposure settings
-        from homeassistant.components import conversation as ha_conversation
-        from homeassistant.components.homeassistant.exposed_entities import async_should_expose
+    def _refresh_exposed_entities(self) -> None:
+        """Recompute the exposed-entity allow-list from Home Assistant's current
+        exposure settings and store it as a NEW frozenset on ``self``.
 
-        exposed_entity_ids = {
+        The ha_control / ha_query tools read it through a provider callable
+        (``lambda: self._exposed_entity_ids``), so reassigning a fresh set here —
+        rather than mutating a shared one in place — keeps the value immutable and
+        avoids handing the tools a mutable reference. Called once at tool
+        registration and again at the start of every conversation turn. This kills
+        a cold-boot race: the agent registers its tools lazily on the first
+        message, but on a fresh boot that message can arrive before late
+        integrations (MQTT / Zigbee discovery) have published their entity states.
+        A one-shot snapshot would freeze those entities out for the life of the
+        agent (HA still has them flagged exposed, but they were absent from
+        hass.states at snapshot time). Re-reading exposure each turn lets them
+        become controllable on the next turn instead.
+        """
+        from homeassistant.components import conversation as ha_conversation
+        from homeassistant.components.homeassistant.exposed_entities import (
+            async_should_expose,
+        )
+
+        current = frozenset(
             state.entity_id
             for state in self.hass.states.async_all()
             if async_should_expose(self.hass, ha_conversation.DOMAIN, state.entity_id)
-        }
-
-        _LOGGER.debug(
-            "Found %d exposed entities for tools: %s",
-            len(exposed_entity_ids),
-            sorted(exposed_entity_ids),
         )
+        previous = getattr(self, "_exposed_entity_ids", frozenset())
+        if current != previous:
+            self._exposed_entity_ids = current
+            _LOGGER.debug(
+                "Refreshed exposed entities for tools: %d total (+%d, -%d)",
+                len(current), len(current - previous), len(previous - current),
+            )
+
+    def _register_tools(self) -> None:
+        """Register core Home Assistant tools."""
+        # Exposed entities respect Home Assistant's exposure settings
+        # (async_should_expose). The allow-list is held on self and recomputed as
+        # a fresh frozenset each turn by _refresh_exposed_entities(); the tools
+        # read the current value through a provider callable (no shared mutable
+        # reference), so a cold-boot discovery race can't freeze entities out.
+        self._exposed_entity_ids: frozenset[str] = frozenset()
+        self._refresh_exposed_entities()
+
+        def exposed_provider() -> frozenset[str]:
+            return self._exposed_entity_ids
 
         # Register ha_control tool
-        ha_control = HomeAssistantControlTool(self.hass, exposed_entity_ids)
+        ha_control = HomeAssistantControlTool(self.hass, exposed_provider)
         self.tool_handler.register_tool(ha_control)
 
         # Register ha_query tool
-        ha_query = HomeAssistantQueryTool(self.hass, exposed_entity_ids)
+        ha_query = HomeAssistantQueryTool(self.hass, exposed_provider)
         self.tool_handler.register_tool(ha_query)
 
         # Register external LLM tool if enabled

--- a/custom_components/home_agent/tools/ha_control.py
+++ b/custom_components/home_agent/tools/ha_control.py
@@ -7,6 +7,7 @@ actions on Home Assistant entities (turn_on, turn_off, toggle, set_value).
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.cover import CoverEntityFeature
@@ -70,15 +71,17 @@ class HomeAssistantControlTool(BaseTool):
     def __init__(
         self,
         hass: HomeAssistant,
-        exposed_entities: set[str] | None = None,
+        exposed_entities: set[str] | Callable[[], frozenset[str] | set[str]] | None = None,
     ) -> None:
         """Initialize the Home Assistant control tool.
 
         Args:
             hass: Home Assistant instance
-            exposed_entities: Optional set of entity IDs that are exposed
-                for control. If None, all entities are accessible (not
-                recommended for production).
+            exposed_entities: Exposed entity IDs that may be controlled — either a
+                set, or a zero-arg provider returning the current set (lets the
+                agent refresh the allow-list without sharing a mutable reference).
+                If None, all entities are accessible (not recommended for
+                production).
         """
         super().__init__(hass)
         self._exposed_entities = exposed_entities
@@ -268,12 +271,22 @@ class HomeAssistantControlTool(BaseTool):
         Raises:
             PermissionDenied: If entity is not accessible
         """
+        # exposed_entities may be a set or a zero-arg provider returning the
+        # current set. The provider lets the agent hand out a fresh (immutable)
+        # set each turn instead of sharing a mutable reference the tool would
+        # have to see mutated in place.
+        exposed = (
+            self._exposed_entities()
+            if callable(self._exposed_entities)
+            else self._exposed_entities
+        )
+
         # If no exposed entities set is provided, allow all access
         # (not recommended for production, but useful for testing)
-        if self._exposed_entities is None:
+        if exposed is None:
             return
 
-        if entity_id not in self._exposed_entities:
+        if entity_id not in exposed:
             _LOGGER.warning(
                 "Attempted access to unexposed entity: %s",
                 entity_id,

--- a/custom_components/home_agent/tools/ha_query.py
+++ b/custom_components/home_agent/tools/ha_query.py
@@ -10,6 +10,7 @@ import asyncio
 import fnmatch
 import logging
 import re
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -88,14 +89,15 @@ class HomeAssistantQueryTool(BaseTool):
     def __init__(
         self,
         hass: HomeAssistant,
-        exposed_entities: set[str] | None = None,
+        exposed_entities: set[str] | Callable[[], frozenset[str] | set[str]] | None = None,
     ) -> None:
         """Initialize the Home Assistant query tool.
 
         Args:
             hass: Home Assistant instance
-            exposed_entities: Optional set of entity IDs that are exposed
-                for querying. If None, all entities are accessible.
+            exposed_entities: Exposed entity IDs that may be queried — either a
+                set, or a zero-arg provider returning the current set. If None,
+                all entities are accessible.
         """
         super().__init__(hass)
         self._exposed_entities = exposed_entities
@@ -343,11 +345,21 @@ class HomeAssistantQueryTool(BaseTool):
         Raises:
             PermissionDenied: If entity is not accessible
         """
+        # exposed_entities may be a set or a zero-arg provider returning the
+        # current set. The provider lets the agent hand out a fresh (immutable)
+        # set each turn instead of sharing a mutable reference the tool would
+        # have to see mutated in place.
+        exposed = (
+            self._exposed_entities()
+            if callable(self._exposed_entities)
+            else self._exposed_entities
+        )
+
         # If no exposed entities set is provided, allow all access
-        if self._exposed_entities is None:
+        if exposed is None:
             return
 
-        if entity_id not in self._exposed_entities:
+        if entity_id not in exposed:
             _LOGGER.warning(
                 "Attempted access to unexposed entity: %s",
                 entity_id,

--- a/tests/unit/test_tools/test_ha_control.py
+++ b/tests/unit/test_tools/test_ha_control.py
@@ -364,6 +364,24 @@ class TestHomeAssistantControlTool:
         assert "not accessible" in str(exc_info.value).lower()
         assert "light.secret_room" in str(exc_info.value)
 
+    def test_exposed_entities_provider_resolved_live(self, mock_hass):
+        """A provider callable is resolved on every access check, so the agent can
+        hand out a FRESH (immutable) set each turn and the tool sees it
+        immediately — without sharing a mutable reference that gets mutated in
+        place. This is the cold-boot exposure-refresh contract."""
+        holder = {"set": frozenset()}
+        tool = HomeAssistantControlTool(mock_hass, lambda: holder["set"])
+
+        # Empty allow-list -> denied.
+        with pytest.raises(PermissionDenied):
+            tool._validate_entity_access("light.living_room")
+
+        # Agent reassigns a brand-new frozenset that now exposes the entity.
+        holder["set"] = frozenset({"light.living_room"})
+
+        # Resolved live through the provider -> now allowed (must not raise).
+        tool._validate_entity_access("light.living_room")
+
     @pytest.mark.asyncio
     async def test_entity_access_validation_none_allows_all(self, mock_hass, sample_light_state):
         """Test that None exposed_entities allows all access."""


### PR DESCRIPTION
### Problem
`_register_tools` snapshots the exposed-entity allow-list once (`hass.states` filtered by `async_should_expose`) and freezes it for the agent's life. Tools register lazily on the first message, but on a fresh boot that message can arrive **before** late integrations (MQTT / Zigbee discovery) have published their entity states — so those entities are absent from the snapshot and stay "unexposed" for good, even though HA has them flagged exposed.

Symptom: `PermissionDenied: '<entity>' is not accessible` while HA controls the same entity fine; only a reload/restart healed it.

### Fix
Recompute the allow-list at the start of **every** conversation turn (`_refresh_exposed_entities`), storing a fresh `frozenset` on `self`. `ha_control` / `ha_query` read it through a **provider callable**, so they see each refresh without sharing a mutable reference (immutable value — no in-place `clear()+update()`).

The tool constructors accept a `set` **or** a zero-arg provider, so existing callers and tests are unaffected.

### Tests
Added a provider-resolution test (a reassigned set is seen live); `test_ha_control` / `test_ha_query` / `test_init` pass (157).