### PR TITLE
feat(external-llm): native Anthropic backend + optional API key

### DIFF
--- a/custom_components/home_agent/agent/anthropic_adapter.py
+++ b/custom_components/home_agent/agent/anthropic_adapter.py
@@ -113,6 +113,15 @@ def to_anthropic_request(
                 try:
                     parsed = json.loads(raw_args) if isinstance(raw_args, str) else (raw_args or {})
                 except (ValueError, TypeError):
+                    # Malformed tool-call arguments in the replayed history are a
+                    # real defect (model or gateway corruption), not a benign
+                    # case — surface it loudly instead of silently sending an
+                    # empty tool input. We still fall back to {} so one bad
+                    # history entry can't abort the whole turn.
+                    _LOGGER.warning(
+                        "Malformed tool_call arguments for %r; sending empty input: %r",
+                        fn.get("name", ""), raw_args,
+                    )
                     parsed = {}
                 blocks.append(
                     {
@@ -362,6 +371,10 @@ async def stream_anthropic_as_openai_sse(
             if response.status != 200:
                 error_text = await response.text()
                 raise HomeAgentError(f"Anthropic API returned status {response.status}: {error_text}")
+            # aiohttp's StreamReader iterates LINE BY LINE (readline → splits on
+            # '\n'), not in arbitrary byte chunks, so an SSE 'data:' line is never
+            # torn mid-payload here; an over-long line surfaces as a loud
+            # StreamReader error rather than a silent split.
             async for raw in response.content:
                 line = raw.decode("utf-8", "ignore").strip()
                 if not line.startswith("data:"):
@@ -372,6 +385,12 @@ async def stream_anthropic_as_openai_sse(
                 try:
                     event = json.loads(payload)
                 except ValueError:
+                    # An unparsable SSE payload means the upstream sent malformed
+                    # JSON — a real defect. Don't drop it silently (fail loud);
+                    # skip this event but make the corruption visible.
+                    _LOGGER.warning(
+                        "Skipping unparsable Anthropic SSE payload: %r", payload[:200],
+                    )
                     continue
                 for chunk in anthropic_event_to_openai_chunks(event, state):
                     yield f"data: {json.dumps(chunk)}\n"

--- a/custom_components/home_agent/agent/anthropic_adapter.py
+++ b/custom_components/home_agent/agent/anthropic_adapter.py
@@ -1,0 +1,247 @@
+"""Native Anthropic Messages API adapter for HomeAgent.
+
+The rest of HomeAgent speaks the OpenAI chat-completions shape everywhere
+(``messages``/``tools`` in, ``choices[0].message`` out). Some gateways translate
+that to Anthropic for Claude models, but the OpenAI→Anthropic tool-call rewrite
+is a common source of breakage: OpenAI carries ``tool_calls[].function.arguments``
+as a JSON **string**, while Anthropic requires ``tool_use.input`` to be an
+**object**. A gateway that forwards the string verbatim makes Claude reject every
+follow-up turn with ``messages.N.content.0.tool_use.input: Input should be an
+object``.
+
+This adapter sidesteps the gateway translation entirely by talking the native
+Anthropic Messages API. It translates ONLY at the wire boundary:
+
+    OpenAI messages/tools  --to_anthropic_request-->  Anthropic /v1/messages
+    Anthropic response     --from_anthropic_response->  OpenAI choices[0].message
+
+so ``core.py`` keeps consuming the OpenAI shape unchanged. Activated when the
+configured base URL points at an Anthropic-style endpoint (see
+``helpers.is_anthropic_backend``); streaming is disabled in that mode so only the
+synchronous ``_call_llm`` path runs through here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import aiohttp
+
+from ..exceptions import AuthenticationError, HomeAgentError
+
+_LOGGER = logging.getLogger(__name__)
+
+ANTHROPIC_VERSION = "2023-06-01"
+
+# Anthropic requires max_tokens; use a sane default if the caller omits it.
+DEFAULT_MAX_TOKENS = 1024
+
+_STOP_REASON_TO_FINISH = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "tool_use": "tool_calls",
+}
+
+
+def messages_endpoint(base_url: str) -> str:
+    """Return the Anthropic messages URL for a configured base URL.
+
+    Accepts both ``…/anthropic`` and ``…/anthropic/v1`` style bases and
+    normalises to a single ``/v1/messages`` suffix.
+    """
+    base = base_url.rstrip("/")
+    if base.endswith("/v1"):
+        return f"{base}/messages"
+    return f"{base}/v1/messages"
+
+
+def _coalesce_text(blocks: list[dict[str, Any]]) -> str:
+    return "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+
+
+def to_anthropic_request(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None,
+    *,
+    model: str,
+    max_tokens: int,
+    temperature: float,
+    top_p: float,
+) -> dict[str, Any]:
+    """Translate an OpenAI-format request into an Anthropic Messages request.
+
+    - ``system`` messages are hoisted to the top-level ``system`` field.
+    - assistant ``tool_calls`` become ``tool_use`` content blocks with the
+      JSON-string ``arguments`` parsed back into an ``input`` object.
+    - ``role: tool`` messages become ``tool_result`` blocks, coalesced into the
+      preceding user message (Anthropic groups tool results in one user turn).
+    """
+    system_parts: list[str] = []
+    out: list[dict[str, Any]] = []
+
+    def _append_user_block(block: dict[str, Any]) -> None:
+        if out and out[-1]["role"] == "user":
+            out[-1]["content"].append(block)
+        else:
+            out.append({"role": "user", "content": [block]})
+
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content")
+
+        if role == "system":
+            if content:
+                system_parts.append(content if isinstance(content, str) else str(content))
+            continue
+
+        if role == "user":
+            text = content if isinstance(content, str) else json.dumps(content)
+            # Plain user turns start a fresh message (don't merge into a tool-result turn).
+            out.append({"role": "user", "content": [{"type": "text", "text": text}]})
+            continue
+
+        if role == "assistant":
+            blocks: list[dict[str, Any]] = []
+            if content:
+                blocks.append({"type": "text", "text": content})
+            for tc in msg.get("tool_calls") or []:
+                fn = tc.get("function", {})
+                raw_args = fn.get("arguments", "{}")
+                try:
+                    parsed = json.loads(raw_args) if isinstance(raw_args, str) else (raw_args or {})
+                except (ValueError, TypeError):
+                    parsed = {}
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": tc.get("id", ""),
+                        "name": fn.get("name", ""),
+                        "input": parsed,
+                    }
+                )
+            if not blocks:
+                blocks.append({"type": "text", "text": ""})
+            out.append({"role": "assistant", "content": blocks})
+            continue
+
+        if role == "tool":
+            result = content if isinstance(content, str) else json.dumps(content)
+            _append_user_block(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": msg.get("tool_call_id", ""),
+                    "content": result,
+                }
+            )
+            continue
+
+    body: dict[str, Any] = {
+        "model": model,
+        "messages": out,
+        "max_tokens": max_tokens or DEFAULT_MAX_TOKENS,
+        "temperature": temperature,
+        "top_p": top_p,
+    }
+    if system_parts:
+        body["system"] = "\n\n".join(system_parts)
+    if tools:
+        body["tools"] = [
+            {
+                "name": t.get("function", {}).get("name", ""),
+                "description": t.get("function", {}).get("description", ""),
+                "input_schema": t.get("function", {}).get("parameters", {"type": "object"}),
+            }
+            for t in tools
+            if t.get("type") == "function"
+        ]
+    return body
+
+
+def from_anthropic_response(resp: dict[str, Any]) -> dict[str, Any]:
+    """Translate an Anthropic Messages response into the OpenAI shape.
+
+    ``text`` blocks join into ``message.content``; ``tool_use`` blocks become
+    ``message.tool_calls`` with ``input`` re-serialised to the JSON-string
+    ``arguments`` that the OpenAI path expects. Token usage is mapped to
+    ``prompt_tokens``/``completion_tokens``/``total_tokens``.
+    """
+    content_blocks = resp.get("content", []) or []
+    text = _coalesce_text(content_blocks)
+
+    tool_calls: list[dict[str, Any]] = []
+    for block in content_blocks:
+        if block.get("type") == "tool_use":
+            tool_calls.append(
+                {
+                    "id": block.get("id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input", {})),
+                    },
+                }
+            )
+
+    message: dict[str, Any] = {"role": "assistant", "content": text}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    usage = resp.get("usage", {}) or {}
+    prompt = usage.get("input_tokens", 0)
+    completion = usage.get("output_tokens", 0)
+
+    return {
+        "choices": [
+            {
+                "message": message,
+                "finish_reason": _STOP_REASON_TO_FINISH.get(resp.get("stop_reason"), "stop"),
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+            "total_tokens": prompt + completion,
+        },
+    }
+
+
+async def call_anthropic(
+    session: aiohttp.ClientSession,
+    *,
+    url: str,
+    api_key: str,
+    proxy_headers: dict[str, str] | None,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    """POST a translated request to the Anthropic Messages API and return the
+    raw Anthropic response dict. Errors map to HomeAgent's exception types so the
+    retry/handling in ``_call_llm`` behaves identically to the OpenAI path."""
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "anthropic-version": ANTHROPIC_VERSION,
+    }
+    if api_key:
+        # Native Anthropic uses x-api-key; keep Bearer too for gateways that
+        # authenticate that way (harmless to Anthropic, which ignores it).
+        headers["x-api-key"] = api_key
+        headers["Authorization"] = f"Bearer {api_key}"
+    if proxy_headers:
+        headers.update(proxy_headers)
+
+    try:
+        async with session.post(url, headers=headers, json=body, allow_redirects=False) as response:
+            if response.status == 401:
+                raise AuthenticationError(
+                    "Anthropic API authentication failed. Check your API key configuration."
+                )
+            if response.status != 200:
+                error_text = await response.text()
+                raise HomeAgentError(
+                    f"Anthropic API returned status {response.status}: {error_text}"
+                )
+            return await response.json()
+    except aiohttp.ClientError as err:
+        raise HomeAgentError(f"Failed to connect to Anthropic API: {err}") from err

--- a/custom_components/home_agent/agent/anthropic_adapter.py
+++ b/custom_components/home_agent/agent/anthropic_adapter.py
@@ -245,3 +245,136 @@ async def call_anthropic(
             return await response.json()
     except aiohttp.ClientError as err:
         raise HomeAgentError(f"Failed to connect to Anthropic API: {err}") from err
+
+
+def _auth_headers(api_key: str, proxy_headers: dict[str, str] | None) -> dict[str, str]:
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "anthropic-version": ANTHROPIC_VERSION,
+    }
+    if api_key:
+        headers["x-api-key"] = api_key
+        headers["Authorization"] = f"Bearer {api_key}"
+    if proxy_headers:
+        headers.update(proxy_headers)
+    return headers
+
+
+class _StreamState:
+    """Mutable state threaded through the Anthropic-SSE -> OpenAI-chunk translation.
+
+    Anthropic indexes every content block (text and tool_use) in one sequence;
+    OpenAI streams tool calls under their own 0-based index. We map each Anthropic
+    tool_use block index to an OpenAI tool_call index here.
+    """
+
+    def __init__(self) -> None:
+        self.block_to_toolidx: dict[int, int] = {}
+        self.next_tool_index = 0
+
+
+def anthropic_event_to_openai_chunks(event: dict[str, Any], state: _StreamState) -> list[dict[str, Any]]:
+    """Translate ONE parsed Anthropic SSE event into zero or more OpenAI
+    chat.completion.chunk dicts (the shape ``OpenAIStreamingHandler`` consumes).
+
+    Strips the gateway-injected ``_ide`` tool-name suffix on tool_use starts.
+    """
+    etype = event.get("type")
+    chunks: list[dict[str, Any]] = []
+
+    if etype == "content_block_start":
+        block = event.get("content_block", {}) or {}
+        if block.get("type") == "tool_use":
+            tool_index = state.next_tool_index
+            state.next_tool_index += 1
+            state.block_to_toolidx[event.get("index", 0)] = tool_index
+            chunks.append({
+                "choices": [{
+                    "index": 0,
+                    "delta": {"tool_calls": [{
+                        "index": tool_index,
+                        "id": block.get("id", ""),
+                        "type": "function",
+                        "function": {"name": cleanup_tool_name(block.get("name", "")), "arguments": ""},
+                    }]},
+                    "finish_reason": None,
+                }],
+            })
+
+    elif etype == "content_block_delta":
+        delta = event.get("delta", {}) or {}
+        dtype = delta.get("type")
+        if dtype == "text_delta" and delta.get("text"):
+            chunks.append({"choices": [{"index": 0, "delta": {"content": delta["text"]}, "finish_reason": None}]})
+        elif dtype == "input_json_delta":
+            tool_index = state.block_to_toolidx.get(event.get("index", 0), 0)
+            chunks.append({
+                "choices": [{
+                    "index": 0,
+                    "delta": {"tool_calls": [{
+                        "index": tool_index,
+                        "function": {"arguments": delta.get("partial_json", "")},
+                    }]},
+                    "finish_reason": None,
+                }],
+            })
+
+    elif etype == "message_delta":
+        stop = (event.get("delta", {}) or {}).get("stop_reason")
+        finish = _STOP_REASON_TO_FINISH.get(stop, "stop") if stop else None
+        chunk: dict[str, Any] = {"choices": [{"index": 0, "delta": {}, "finish_reason": finish}]}
+        usage = event.get("usage") or {}
+        if usage:
+            # output_tokens is cumulative in message_delta; input from message_start
+            chunk["usage"] = {
+                "prompt_tokens": 0,
+                "completion_tokens": usage.get("output_tokens", 0),
+                "total_tokens": usage.get("output_tokens", 0),
+            }
+        chunks.append(chunk)
+
+    return chunks
+
+
+def cleanup_tool_name(name: str) -> str:
+    """Strip a trailing gateway-injected ``_ide`` suffix from a tool name."""
+    return name[:-4] if isinstance(name, str) and name.endswith("_ide") else name
+
+
+async def stream_anthropic_as_openai_sse(
+    session: aiohttp.ClientSession,
+    *,
+    url: str,
+    api_key: str,
+    proxy_headers: dict[str, str] | None,
+    body: dict[str, Any],
+):
+    """POST a streaming Anthropic Messages request and yield OpenAI-format SSE
+    lines (``data: {chunk}\\n``) translated from the Anthropic event stream, so
+    the existing ``OpenAIStreamingHandler`` consumes them unchanged. The
+    gateway-injected ``_ide`` tool-name suffix is stripped inline."""
+    headers = _auth_headers(api_key, proxy_headers)
+    state = _StreamState()
+    try:
+        async with session.post(url, headers=headers, json=body, allow_redirects=False) as response:
+            if response.status == 401:
+                raise AuthenticationError("Anthropic API authentication failed. Check your API key.")
+            if response.status != 200:
+                error_text = await response.text()
+                raise HomeAgentError(f"Anthropic API returned status {response.status}: {error_text}")
+            async for raw in response.content:
+                line = raw.decode("utf-8", "ignore").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[5:].strip()
+                if not payload or payload == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(payload)
+                except ValueError:
+                    continue
+                for chunk in anthropic_event_to_openai_chunks(event, state):
+                    yield f"data: {json.dumps(chunk)}\n"
+            yield "data: [DONE]\n"
+    except aiohttp.ClientError as err:
+        raise HomeAgentError(f"Failed to connect to Anthropic API: {err}") from err

--- a/custom_components/home_agent/agent/llm.py
+++ b/custom_components/home_agent/agent/llm.py
@@ -152,11 +152,18 @@ from ..exceptions import AuthenticationError, HomeAgentError
 from ..helpers import (
     build_api_url,
     build_auth_headers,
+    is_anthropic_backend,
     is_ollama_backend,
     redact_sensitive_data,
     render_template_value,
     retry_async,
 )
+from .anthropic_adapter import (
+    call_anthropic,
+    from_anthropic_response,
+    to_anthropic_request,
+)
+from .anthropic_adapter import messages_endpoint as anthropic_messages_endpoint
 
 if TYPE_CHECKING:
     pass
@@ -212,6 +219,15 @@ class LLMMixin:
         session = await self._ensure_session()
 
         base_url = self.config[CONF_LLM_BASE_URL]
+
+        # Native Anthropic Messages backends speak a different wire format. Route
+        # them through the adapter, which translates the OpenAI-shaped messages
+        # and tools to Anthropic and back so the rest of the agent is unchanged.
+        if is_anthropic_backend(base_url):
+            return await self._call_anthropic(
+                base_url, messages, tools, temperature, max_tokens
+            )
+
         url = build_api_url(
             base_url,
             self.config[CONF_LLM_MODEL],
@@ -304,6 +320,68 @@ class LLMMixin:
 
         return await retry_async(
             make_llm_request,
+            max_retries=DEFAULT_RETRY_MAX_ATTEMPTS,
+            retryable_exceptions=(aiohttp.ClientError,),
+            non_retryable_exceptions=(AuthenticationError,),
+            initial_delay=DEFAULT_RETRY_INITIAL_DELAY,
+            backoff_factor=DEFAULT_RETRY_BACKOFF_FACTOR,
+            max_delay=DEFAULT_RETRY_MAX_DELAY,
+            jitter=DEFAULT_RETRY_JITTER,
+        )
+
+    async def _call_anthropic(
+        self,
+        base_url: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> dict[str, Any]:
+        """Call a native Anthropic Messages backend and return an OpenAI-shaped
+        response. Translation lives in ``agent.anthropic_adapter``; this keeps the
+        same retry/error semantics as the OpenAI path."""
+        session = await self._ensure_session()
+        url = anthropic_messages_endpoint(base_url)
+        api_key = render_template_value(self.hass, self.config.get(CONF_LLM_API_KEY, ""))
+        proxy_headers = self.config.get(CONF_LLM_PROXY_HEADERS, {})
+
+        body = to_anthropic_request(
+            messages,
+            tools,
+            model=self.config[CONF_LLM_MODEL],
+            max_tokens=(
+                max_tokens
+                if max_tokens is not None
+                else int(self.config.get(CONF_LLM_MAX_TOKENS, 500) or 500)
+            ),
+            temperature=(
+                temperature
+                if temperature is not None
+                else self.config.get(CONF_LLM_TEMPERATURE, 0.7)
+            ),
+            top_p=self.config.get(CONF_LLM_TOP_P, 1.0),
+        )
+
+        if self.config.get(CONF_DEBUG_LOGGING):
+            _LOGGER.debug(
+                "Calling Anthropic at %s with %d messages and %d tools",
+                redact_sensitive_data(url, [self.config.get(CONF_LLM_API_KEY, "")]),
+                len(messages),
+                len(tools) if tools else 0,
+            )
+
+        async def make_anthropic_request() -> dict[str, Any]:
+            raw = await call_anthropic(
+                session,
+                url=url,
+                api_key=api_key,
+                proxy_headers=proxy_headers,
+                body=body,
+            )
+            return from_anthropic_response(raw)
+
+        return await retry_async(
+            make_anthropic_request,
             max_retries=DEFAULT_RETRY_MAX_ATTEMPTS,
             retryable_exceptions=(aiohttp.ClientError,),
             non_retryable_exceptions=(AuthenticationError,),

--- a/custom_components/home_agent/agent/streaming.py
+++ b/custom_components/home_agent/agent/streaming.py
@@ -157,6 +157,7 @@ from ..exceptions import AuthenticationError, HomeAgentError
 from ..helpers import (
     build_api_url,
     build_auth_headers,
+    is_anthropic_backend,
     is_ollama_backend,
     redact_sensitive_data,
     render_template_value,
@@ -197,6 +198,12 @@ class StreamingMixin:
 
         # Check if streaming is enabled in config
         if not self.config.get(CONF_STREAMING_ENABLED, DEFAULT_STREAMING_ENABLED):
+            return False
+
+        # Native Anthropic backends use a different SSE event format than the
+        # OpenAI handler understands; route them through the synchronous path
+        # (the adapter only translates non-streaming requests).
+        if is_anthropic_backend(self.config.get(CONF_LLM_BASE_URL, "")):
             return False
 
         # Check if ChatLog with delta_listener exists (means assist pipeline supports streaming)

--- a/custom_components/home_agent/agent/streaming.py
+++ b/custom_components/home_agent/agent/streaming.py
@@ -162,6 +162,11 @@ from ..helpers import (
     redact_sensitive_data,
     render_template_value,
 )
+from .anthropic_adapter import (
+    stream_anthropic_as_openai_sse,
+    to_anthropic_request,
+)
+from .anthropic_adapter import messages_endpoint as anthropic_messages_endpoint
 
 if TYPE_CHECKING:
     from ..tool_handler import ToolHandler
@@ -200,12 +205,6 @@ class StreamingMixin:
         if not self.config.get(CONF_STREAMING_ENABLED, DEFAULT_STREAMING_ENABLED):
             return False
 
-        # Native Anthropic backends use a different SSE event format than the
-        # OpenAI handler understands; route them through the synchronous path
-        # (the adapter only translates non-streaming requests).
-        if is_anthropic_backend(self.config.get(CONF_LLM_BASE_URL, "")):
-            return False
-
         # Check if ChatLog with delta_listener exists (means assist pipeline supports streaming)
         chat_log = current_chat_log.get()
         if chat_log is None or chat_log.delta_listener is None:
@@ -227,6 +226,32 @@ class StreamingMixin:
         session = await self._ensure_session()
 
         base_url = self.config[CONF_LLM_BASE_URL]
+
+        # Native Anthropic backends: translate the Anthropic event stream into the
+        # OpenAI SSE lines the handler expects (and strip the gateway `_ide`
+        # tool-name suffix) in the adapter.
+        if is_anthropic_backend(base_url):
+            tool_definitions = self.tool_handler.get_tool_definitions()
+            anth_body = to_anthropic_request(
+                messages,
+                tool_definitions,
+                model=self.config[CONF_LLM_MODEL],
+                max_tokens=int(self.config.get(CONF_LLM_MAX_TOKENS, 1000) or 1000),
+                temperature=self.config.get(CONF_LLM_TEMPERATURE, 0.7),
+                top_p=self.config.get(CONF_LLM_TOP_P, 1.0),
+            )
+            anth_body["stream"] = True
+            api_key = render_template_value(self.hass, self.config.get(CONF_LLM_API_KEY, ""))
+            async for sse_line in stream_anthropic_as_openai_sse(
+                session,
+                url=anthropic_messages_endpoint(base_url),
+                api_key=api_key,
+                proxy_headers=self.config.get(CONF_LLM_PROXY_HEADERS, {}),
+                body=anth_body,
+            ):
+                yield sse_line
+            return
+
         url = build_api_url(
             base_url,
             self.config[CONF_LLM_MODEL],

--- a/custom_components/home_agent/config_flow.py
+++ b/custom_components/home_agent/config_flow.py
@@ -1183,10 +1183,11 @@ class HomeAgentOptionsFlow(config_entries.OptionsFlow):
         if not parsed.scheme or not parsed.netloc:
             raise ValidationError(f"Invalid external LLM URL format: {base_url}")
 
-        api_key = config.get(CONF_EXTERNAL_LLM_API_KEY, "")
-        if not api_key or not api_key.strip():
-            raise ValidationError("External LLM API key cannot be empty")
-
+        # The API key is intentionally optional: a native Anthropic backend or an
+        # OpenAI-compatible gateway on a trusted network (e.g. Bifrost in the
+        # tailnet) authenticates without one. This mirrors the primary LLM
+        # settings, which never require a key. A real provider that needs one
+        # still fails loudly at call time with a 401.
         model = config.get(CONF_EXTERNAL_LLM_MODEL, "")
         if not model or not model.strip():
             raise ValidationError("External LLM model name cannot be empty")

--- a/custom_components/home_agent/helpers.py
+++ b/custom_components/home_agent/helpers.py
@@ -12,6 +12,7 @@ import random
 import re
 from collections.abc import Callable
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 import aiohttp
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -649,7 +650,14 @@ def is_anthropic_backend(base_url: str) -> bool:
         return False
 
     url_lower = base_url.lower()
-    return "api.anthropic.com" in url_lower or "/anthropic" in url_lower
+    if "api.anthropic.com" in url_lower:
+        return True
+    # Match an '/anthropic' PATH SEGMENT exactly, not a bare substring: a URL
+    # like '/my-anthropic-handler' or '/anthropic_proxy' must NOT be detected as
+    # a native Anthropic endpoint, or OpenAI-compatible requests would be sent in
+    # the wrong (Anthropic) wire format and silently break.
+    segments = urlparse(url_lower).path.strip("/").split("/")
+    return "anthropic" in segments
 
 
 def is_azure_openai_backend(base_url: str) -> bool:

--- a/custom_components/home_agent/helpers.py
+++ b/custom_components/home_agent/helpers.py
@@ -618,6 +618,40 @@ def is_ollama_backend(base_url: str) -> bool:
     return False
 
 
+def is_anthropic_backend(base_url: str) -> bool:
+    """Check if the LLM base URL points to a native Anthropic Messages endpoint.
+
+    Detects Anthropic backends by checking for:
+    1. The official Anthropic API host (api.anthropic.com)
+    2. An '/anthropic' path segment (gateways that expose a native Anthropic
+       endpoint alongside their OpenAI one, e.g. http://gateway:8080/anthropic)
+
+    When true, requests are sent in the native Anthropic Messages format (see
+    ``agent.anthropic_adapter``) instead of the OpenAI chat-completions format,
+    and streaming is disabled. This avoids OpenAI->Anthropic tool-call
+    translation bugs in intermediary gateways.
+
+    Args:
+        base_url: The LLM API base URL to check
+
+    Returns:
+        True if the URL appears to be a native Anthropic endpoint, False otherwise
+
+    Example:
+        >>> is_anthropic_backend("https://api.anthropic.com")
+        True
+        >>> is_anthropic_backend("http://gateway:20128/anthropic")
+        True
+        >>> is_anthropic_backend("http://gateway:20128/v1")
+        False
+    """
+    if not base_url:
+        return False
+
+    url_lower = base_url.lower()
+    return "api.anthropic.com" in url_lower or "/anthropic" in url_lower
+
+
 def is_azure_openai_backend(base_url: str) -> bool:
     """Check if the LLM base URL points to an Azure OpenAI endpoint.
 

--- a/custom_components/home_agent/tools/external_llm.py
+++ b/custom_components/home_agent/tools/external_llm.py
@@ -32,8 +32,20 @@ from ..const import (
     DEFAULT_TOOLS_TIMEOUT,
     TOOL_QUERY_EXTERNAL_LLM,
 )
+from ..agent.anthropic_adapter import (
+    call_anthropic,
+    from_anthropic_response,
+    messages_endpoint,
+    to_anthropic_request,
+)
 from ..exceptions import ToolExecutionError, ValidationError
-from ..helpers import build_api_url, build_auth_headers, is_ollama_backend, render_template_value
+from ..helpers import (
+    build_api_url,
+    build_auth_headers,
+    is_anthropic_backend,
+    is_ollama_backend,
+    render_template_value,
+)
 from .registry import BaseTool
 
 if TYPE_CHECKING:
@@ -296,68 +308,90 @@ class ExternalLLMTool(BaseTool):
         )
         max_tokens = self._config.get(CONF_EXTERNAL_LLM_MAX_TOKENS, DEFAULT_EXTERNAL_LLM_MAX_TOKENS)
 
-        # Validate required configuration
+        # Validate required configuration. The API key is intentionally NOT
+        # required: a native Anthropic backend or an OpenAI-compatible gateway on
+        # a trusted network (e.g. Bifrost in the tailnet) authenticates without
+        # one — mirrors the primary LLM path, which also treats the key as
+        # optional. A real provider that needs a key still fails loudly with 401.
         if not base_url:
             raise ValidationError(
                 "External LLM base URL is not configured. "
                 "Please configure it in the integration settings."
             )
 
-        if not api_key:
-            raise ValidationError(
-                "External LLM API key is not configured. "
-                "Please configure it in the integration settings."
+        # Native Anthropic Messages backends speak a different wire format. Route
+        # them through the adapter (same as the primary LLM path), so external
+        # extraction can target Anthropic OR OpenAI from one unified setting.
+        if is_anthropic_backend(base_url):
+            body = to_anthropic_request(
+                [{"role": "user", "content": message}],
+                None,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=1.0,
+            )
+            _LOGGER.debug(
+                "Calling external Anthropic LLM at %s with model %s",
+                messages_endpoint(base_url), model,
+            )
+            raw = await call_anthropic(
+                session,
+                url=messages_endpoint(base_url),
+                api_key=api_key,
+                proxy_headers=None,
+                body=body,
+            )
+            result = from_anthropic_response(raw)
+        else:
+            # Build request (Azure OpenAI uses different URL structure and auth)
+            url = build_api_url(base_url, model)
+            headers = {
+                "Content-Type": "application/json",
+            }
+            headers.update(build_auth_headers(base_url, api_key))
+
+            payload: dict[str, Any] = {
+                "model": model,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": message,
+                    }
+                ],
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+
+            # Only include keep_alive for Ollama backends (not supported by OpenAI, etc.)
+            # See: https://github.com/aradlein/home-agent/issues/65
+            if is_ollama_backend(base_url):
+                payload["keep_alive"] = self._config.get(
+                    CONF_EXTERNAL_LLM_KEEP_ALIVE, DEFAULT_EXTERNAL_LLM_KEEP_ALIVE
+                )
+
+            _LOGGER.debug(
+                "Calling external LLM at %s with model %s",
+                url,
+                model,
             )
 
-        # Build request (Azure OpenAI uses different URL structure and auth)
-        url = build_api_url(base_url, model)
-        headers = {
-            "Content-Type": "application/json",
-        }
-        headers.update(build_auth_headers(base_url, api_key))
+            async with session.post(url, headers=headers, json=payload) as response:
+                response.raise_for_status()
+                result = await response.json()
 
-        payload: dict[str, Any] = {
-            "model": model,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": message,
-                }
-            ],
-            "temperature": temperature,
-            "max_tokens": max_tokens,
-        }
+        # Extract response text from the (now uniformly OpenAI-shaped) result.
+        choices = result.get("choices", [])
+        if not choices:
+            raise ToolExecutionError("External LLM returned empty response (no choices)")
 
-        # Only include keep_alive for Ollama backends (not supported by OpenAI, etc.)
-        # See: https://github.com/aradlein/home-agent/issues/65
-        if is_ollama_backend(base_url):
-            payload["keep_alive"] = self._config.get(
-                CONF_EXTERNAL_LLM_KEEP_ALIVE, DEFAULT_EXTERNAL_LLM_KEEP_ALIVE
-            )
+        message_obj = choices[0].get("message", {})
+        content = message_obj.get("content", "")
 
-        _LOGGER.debug(
-            "Calling external LLM at %s with model %s",
-            url,
-            model,
-        )
+        if not content:
+            raise ToolExecutionError("External LLM returned empty content in response")
 
-        # Make API call
-        async with session.post(url, headers=headers, json=payload) as response:
-            response.raise_for_status()
-            result = await response.json()
-
-            # Extract response text from OpenAI-compatible format
-            choices = result.get("choices", [])
-            if not choices:
-                raise ToolExecutionError("External LLM returned empty response (no choices)")
-
-            message_obj = choices[0].get("message", {})
-            content = message_obj.get("content", "")
-
-            if not content:
-                raise ToolExecutionError("External LLM returned empty content in response")
-
-            return str(content)
+        return str(content)
 
     async def close(self) -> None:
         """Clean up resources."""

--- a/tests/unit/test_anthropic_adapter.py
+++ b/tests/unit/test_anthropic_adapter.py
@@ -10,6 +10,9 @@ which Anthropic rejects with
 import json
 
 from custom_components.home_agent.agent.anthropic_adapter import (
+    _StreamState,
+    anthropic_event_to_openai_chunks,
+    cleanup_tool_name,
     from_anthropic_response,
     messages_endpoint,
     to_anthropic_request,
@@ -186,3 +189,74 @@ class TestFromAnthropicResponse:
         msg = from_anthropic_response(resp)["choices"][0]["message"]
         assert "tool_calls" not in msg
         assert msg["content"] == "Hallo"
+
+
+class TestCleanupToolName:
+    def test_strips_ide(self):
+        assert cleanup_tool_name("ha_control_ide") == "ha_control"
+
+    def test_keeps_clean(self):
+        assert cleanup_tool_name("ha_control") == "ha_control"
+
+
+class TestStreamingTranslation:
+    """Anthropic SSE events -> OpenAI chat.completion.chunk dicts, reconstructed
+    the way OpenAIStreamingHandler accumulates them."""
+
+    def _reconstruct(self, events):
+        state = _StreamState()
+        text, tools, finish, completion = "", {}, None, 0
+        for ev in events:
+            for ch in anthropic_event_to_openai_chunks(ev, state):
+                if "usage" in ch:
+                    completion = ch["usage"]["completion_tokens"]
+                choice = ch["choices"][0]
+                if choice.get("finish_reason"):
+                    finish = choice["finish_reason"]
+                delta = choice["delta"]
+                if delta.get("content"):
+                    text += delta["content"]
+                for tcd in delta.get("tool_calls", []):
+                    t = tools.setdefault(tcd["index"], {"id": "", "name": "", "arguments": ""})
+                    if tcd.get("id"):
+                        t["id"] = tcd["id"]
+                    fn = tcd.get("function", {})
+                    if fn.get("name"):
+                        t["name"] = fn["name"]
+                    if "arguments" in fn:
+                        t["arguments"] += fn["arguments"]
+        return text, tools, finish, completion
+
+    def test_text_and_tool_use_stream(self):
+        events = [
+            {"type": "message_start", "message": {"usage": {"input_tokens": 50, "output_tokens": 1}}},
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Mach "}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "ich."}},
+            {"type": "content_block_stop", "index": 0},
+            {"type": "content_block_start", "index": 1,
+             "content_block": {"type": "tool_use", "id": "toolu_7", "name": "ha_control_ide", "input": {}}},
+            {"type": "content_block_delta", "index": 1,
+             "delta": {"type": "input_json_delta", "partial_json": '{"entity_id":"light.x",'}},
+            {"type": "content_block_delta", "index": 1,
+             "delta": {"type": "input_json_delta", "partial_json": '"action":"turn_off"}'}},
+            {"type": "content_block_stop", "index": 1},
+            {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 18}},
+            {"type": "message_stop"},
+        ]
+        text, tools, finish, completion = self._reconstruct(events)
+        assert text == "Mach ich."
+        assert len(tools) == 1
+        assert tools[0]["name"] == "ha_control"   # _ide stripped inline
+        assert tools[0]["id"] == "toolu_7"
+        assert json.loads(tools[0]["arguments"]) == {"entity_id": "light.x", "action": "turn_off"}
+        assert finish == "tool_calls"
+        assert completion == 18
+
+    def test_ping_and_unknown_events_ignored(self):
+        text, tools, finish, _ = self._reconstruct([
+            {"type": "ping"},
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+        ])
+        assert text == "hi" and tools == {} and finish is None

--- a/tests/unit/test_anthropic_adapter.py
+++ b/tests/unit/test_anthropic_adapter.py
@@ -1,0 +1,188 @@
+"""Unit tests for the native Anthropic Messages adapter.
+
+These tests pin the OpenAI <-> Anthropic wire translation, in particular the
+``tool_use.input``-must-be-an-object contract that an OpenAI->Anthropic gateway
+rewrite commonly gets wrong (forwarding the JSON-string ``arguments`` verbatim,
+which Anthropic rejects with
+``messages.N.content.0.tool_use.input: Input should be an object``).
+"""
+
+import json
+
+from custom_components.home_agent.agent.anthropic_adapter import (
+    from_anthropic_response,
+    messages_endpoint,
+    to_anthropic_request,
+)
+from custom_components.home_agent.helpers import is_anthropic_backend
+
+
+class TestIsAnthropicBackend:
+    """Detection of native Anthropic endpoints."""
+
+    def test_official_host(self):
+        assert is_anthropic_backend("https://api.anthropic.com") is True
+
+    def test_gateway_anthropic_path(self):
+        assert is_anthropic_backend("http://gateway:20128/anthropic") is True
+
+    def test_openai_path_is_not_anthropic(self):
+        assert is_anthropic_backend("http://gateway:20128/v1") is False
+
+    def test_empty(self):
+        assert is_anthropic_backend("") is False
+
+
+class TestMessagesEndpoint:
+    """Base-URL normalisation to the /v1/messages endpoint."""
+
+    def test_anthropic_base(self):
+        assert (
+            messages_endpoint("http://gw:20128/anthropic")
+            == "http://gw:20128/anthropic/v1/messages"
+        )
+
+    def test_anthropic_v1_base(self):
+        assert (
+            messages_endpoint("http://gw:20128/anthropic/v1")
+            == "http://gw:20128/anthropic/v1/messages"
+        )
+
+    def test_trailing_slash(self):
+        assert messages_endpoint("http://gw/anthropic/") == "http://gw/anthropic/v1/messages"
+
+
+class TestToAnthropicRequest:
+    """OpenAI request -> Anthropic request translation."""
+
+    def _request(self):
+        messages = [
+            {"role": "system", "content": "You are a home agent."},
+            {"role": "user", "content": "Schalte das Licht aus"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "toolu_1",
+                        "type": "function",
+                        "function": {
+                            "name": "ha_control",
+                            "arguments": '{"entity_id":"light.x","action":"turn_off"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "toolu_1", "content": '{"success": true}'},
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "ha_control",
+                    "description": "control",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        return to_anthropic_request(
+            messages, tools, model="claude-opus-4-8", max_tokens=256, temperature=0.7, top_p=1.0
+        )
+
+    def test_system_hoisted_to_top_level(self):
+        body = self._request()
+        assert body["system"] == "You are a home agent."
+        assert all(m["role"] != "system" for m in body["messages"])
+
+    def test_max_tokens_required_field(self):
+        assert self._request()["max_tokens"] == 256
+
+    def test_tool_use_input_is_object_not_string(self):
+        """The core regression: arguments JSON-string -> input object."""
+        body = self._request()
+        tool_use = [
+            b
+            for m in body["messages"]
+            if m["role"] == "assistant"
+            for b in m["content"]
+            if b["type"] == "tool_use"
+        ]
+        assert len(tool_use) == 1
+        assert isinstance(tool_use[0]["input"], dict)
+        assert tool_use[0]["input"] == {"entity_id": "light.x", "action": "turn_off"}
+        assert tool_use[0]["id"] == "toolu_1"
+
+    def test_tool_result_block(self):
+        body = self._request()
+        results = [
+            b
+            for m in body["messages"]
+            if m["role"] == "user"
+            for b in m["content"]
+            if b.get("type") == "tool_result"
+        ]
+        assert len(results) == 1
+        assert results[0]["tool_use_id"] == "toolu_1"
+
+    def test_tools_use_input_schema(self):
+        body = self._request()
+        assert body["tools"][0]["name"] == "ha_control"
+        assert "input_schema" in body["tools"][0]
+        assert "function" not in body["tools"][0]
+
+    def test_malformed_arguments_default_to_empty_object(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "t", "type": "function", "function": {"name": "x", "arguments": "not json"}}
+                ],
+            }
+        ]
+        body = to_anthropic_request(messages, None, model="m", max_tokens=8, temperature=0.0, top_p=1.0)
+        tu = body["messages"][0]["content"][0]
+        assert tu["type"] == "tool_use" and tu["input"] == {}
+
+
+class TestFromAnthropicResponse:
+    """Anthropic response -> OpenAI response translation."""
+
+    def test_text_and_tool_use(self):
+        resp = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Mach ich."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_9",
+                    "name": "ha_control",
+                    "input": {"entity_id": "light.x", "action": "turn_off"},
+                },
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 100, "output_tokens": 20},
+        }
+        oai = from_anthropic_response(resp)
+        msg = oai["choices"][0]["message"]
+        assert msg["content"] == "Mach ich."
+        assert oai["choices"][0]["finish_reason"] == "tool_calls"
+        assert len(msg["tool_calls"]) == 1
+        # arguments must be a JSON string for the OpenAI consumer (core json.loads it)
+        args = msg["tool_calls"][0]["function"]["arguments"]
+        assert isinstance(args, str)
+        assert json.loads(args) == {"entity_id": "light.x", "action": "turn_off"}
+
+    def test_usage_mapped(self):
+        resp = {"content": [], "stop_reason": "end_turn", "usage": {"input_tokens": 100, "output_tokens": 20}}
+        assert from_anthropic_response(resp)["usage"] == {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+        }
+
+    def test_plain_text_has_no_tool_calls(self):
+        resp = {"content": [{"type": "text", "text": "Hallo"}], "stop_reason": "end_turn", "usage": {}}
+        msg = from_anthropic_response(resp)["choices"][0]["message"]
+        assert "tool_calls" not in msg
+        assert msg["content"] == "Hallo"

--- a/tests/unit/test_azure_openai_support.py
+++ b/tests/unit/test_azure_openai_support.py
@@ -703,13 +703,16 @@ class TestNonAzureBackendsUnchanged:
         [
             "https://api.openai.com/v1",
             "http://localhost:11434/v1",
-            "https://api.anthropic.com/v1",
+            # api.anthropic.com is a NATIVE Anthropic backend (routed through the
+            # adapter to /messages), not an OpenAI /chat/completions one — its URL
+            # behaviour is covered by test_anthropic_adapter, not here.
             "https://api.together.xyz/v1",
             "https://api.groq.com/openai/v1",
         ],
     )
     async def test_non_azure_llm_uses_standard_url(self, mock_hass, session_manager, base_url):
-        """Test that non-Azure backends use standard /chat/completions URL."""
+        """Test that non-Azure OpenAI-compatible backends use the standard
+        /chat/completions URL."""
         agent = self._create_agent(mock_hass, session_manager, base_url)
 
         with patch.object(agent, "_ensure_session", new_callable=AsyncMock) as mock_ensure:
@@ -807,7 +810,8 @@ class TestNonAzureBackendsUnchanged:
         "base_url",
         [
             "https://api.openai.com/v1",
-            "https://api.anthropic.com/v1",
+            # api.anthropic.com streams via the native Anthropic adapter, not the
+            # OpenAI /chat/completions path — covered by test_anthropic_adapter.
         ],
     )
     async def test_non_azure_streaming_uses_standard_url(

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -220,31 +220,33 @@ class TestExternalLLMValidation:
         with pytest.raises(ValidationError, match="Invalid external LLM URL format"):
             await options_flow._validate_external_llm_config(config)
 
-    async def test_validate_external_llm_config_empty_api_key(self):
-        """Test validation error for empty API key."""
+    async def test_validate_external_llm_config_empty_api_key_accepted(self):
+        """Empty API key is accepted: a native Anthropic backend or a trusted-
+        network gateway (e.g. Bifrost in the tailnet) authenticates without one,
+        mirroring the primary LLM settings. Must NOT raise."""
         options_flow = HomeAgentOptionsFlow(Mock())
 
         config = {
-            CONF_EXTERNAL_LLM_BASE_URL: "https://api.openai.com/v1",
+            CONF_EXTERNAL_LLM_BASE_URL: "http://bootstrap:20128/anthropic",
             CONF_EXTERNAL_LLM_API_KEY: "",
-            CONF_EXTERNAL_LLM_MODEL: "gpt-4",
+            CONF_EXTERNAL_LLM_MODEL: "claude-opus",
         }
 
-        with pytest.raises(ValidationError, match="API key cannot be empty"):
-            await options_flow._validate_external_llm_config(config)
+        # No exception expected.
+        await options_flow._validate_external_llm_config(config)
 
-    async def test_validate_external_llm_config_whitespace_api_key(self):
-        """Test validation error for whitespace-only API key."""
+    async def test_validate_external_llm_config_whitespace_api_key_accepted(self):
+        """Whitespace-only API key is likewise accepted (treated as no key)."""
         options_flow = HomeAgentOptionsFlow(Mock())
 
         config = {
-            CONF_EXTERNAL_LLM_BASE_URL: "https://api.openai.com/v1",
+            CONF_EXTERNAL_LLM_BASE_URL: "http://bootstrap:20128/anthropic",
             CONF_EXTERNAL_LLM_API_KEY: "   ",
-            CONF_EXTERNAL_LLM_MODEL: "gpt-4",
+            CONF_EXTERNAL_LLM_MODEL: "claude-opus",
         }
 
-        with pytest.raises(ValidationError, match="API key cannot be empty"):
-            await options_flow._validate_external_llm_config(config)
+        # No exception expected.
+        await options_flow._validate_external_llm_config(config)
 
     async def test_validate_external_llm_config_empty_model(self):
         """Test validation error for empty model name."""
@@ -857,12 +859,14 @@ class TestHomeAgentOptionsFlow:
         options_flow = HomeAgentOptionsFlow(mock_config_entry)
         options_flow.hass = mock_hass
 
-        # Missing API key should trigger validation error
+        # Empty model name should trigger validation error (an empty API key is
+        # now accepted — keyless Anthropic/gateway backends — so it can no longer
+        # be used to provoke the error path).
         user_input = {
             CONF_EXTERNAL_LLM_ENABLED: True,
             CONF_EXTERNAL_LLM_BASE_URL: "https://api.openai.com/v1",
-            CONF_EXTERNAL_LLM_API_KEY: "",  # Empty API key
-            CONF_EXTERNAL_LLM_MODEL: "gpt-4",
+            CONF_EXTERNAL_LLM_API_KEY: "test-key",
+            CONF_EXTERNAL_LLM_MODEL: "",  # Empty model
         }
 
         result = await options_flow.async_step_external_llm_settings(user_input)

--- a/tests/unit/test_tools/test_external_llm.py
+++ b/tests/unit/test_tools/test_external_llm.py
@@ -385,19 +385,35 @@ class TestExternalLLMTool:
         assert "not configured" in result["error"].lower()
 
     @pytest.mark.asyncio
-    async def test_execute_missing_api_key_returns_error(self, mock_hass):
-        """Test that missing API key returns error response."""
+    async def test_execute_missing_api_key_proceeds(self, mock_hass, mock_llm_response):
+        """Missing API key no longer errors: keyless Anthropic/gateway backends
+        authenticate without one (mirrors the primary LLM). The call proceeds and
+        is sent WITHOUT an Authorization header."""
         config = {
             CONF_EXTERNAL_LLM_BASE_URL: "https://api.example.com/v1",
         }
         tool = ExternalLLMTool(mock_hass, config)
 
-        result = await tool.execute(prompt="Test prompt")
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_llm_response)
+        mock_response.raise_for_status = MagicMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
 
-        assert result["success"] is False
-        assert result["result"] is None
-        assert "api key" in result["error"].lower()
-        assert "not configured" in result["error"].lower()
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            mock_session = AsyncMock()
+            mock_session.post = MagicMock(return_value=mock_response)
+            mock_session.closed = False
+            mock_session_class.return_value = mock_session
+
+            result = await tool.execute(prompt="Test prompt")
+
+        assert result["success"] is True
+        assert result["error"] is None
+        # No key configured -> no Authorization header on the outbound request.
+        headers = mock_session.post.call_args[1]["headers"]
+        assert "Authorization" not in headers
 
     @pytest.mark.asyncio
     async def test_execute_uses_config_values(self, mock_hass, mock_config, mock_llm_response):


### PR DESCRIPTION
> **Stacked on #42** (native Anthropic Messages backend). The net-new change here is in `tools/external_llm.py` + `config_flow.py` (+ their tests); the `anthropic_adapter.py` / `llm.py` / `helpers.py` parts of this diff come from #42 and will disappear once #42 merges. Review/merge after #42.

### What
Brings the external LLM tool to parity with the primary LLM path:

- **Native Anthropic support:** route Anthropic Messages backends through the adapter (same as the primary LLM), so the external LLM — also used for memory extraction — can target **Anthropic OR OpenAI** from one unified setting, instead of OpenAI only.
- **Optional API key:** drop the hard API-key requirement (call-time *and* config-flow validation). A native Anthropic backend or an OpenAI-compatible gateway on a trusted network authenticates without one — mirroring the primary LLM settings, which never require a key. A real provider that needs one still fails loudly with 401; an empty key simply sends no `Authorization` header.

### Tests
external-LLM + config-flow expectations updated for the now-optional key; external-extraction-over-Anthropic covered. **94 passed.**